### PR TITLE
Make: clean before building to avoid stale references to FB frameworks

### DIFF
--- a/bin/make/dependencies.sh
+++ b/bin/make/dependencies.sh
@@ -52,7 +52,9 @@ HERE=$(pwd)
 cp LICENSE "${OUTPUT_DIR}"
 cp vendor-licenses/* "${OUTPUT_DIR}/Frameworks"
 
+make clean
 make build
+
 cp "Products/${EXECUTABLE}" "${OUTPUT_DIR}/bin"
 
 info "Gathered dependencies in ${OUTPUT_DIR}"


### PR DESCRIPTION
### Motivation

This will ensure you don't get the dread "Cannot find some Facebook framework header" when making dependencies.
