### PR TITLE
cp CLI.json to bin dir for dependencies

### DIFF
--- a/bin/make/dependencies.sh
+++ b/bin/make/dependencies.sh
@@ -54,5 +54,6 @@ cp vendor-licenses/* "${OUTPUT_DIR}/Frameworks"
 
 make build
 cp "Products/${EXECUTABLE}" "${OUTPUT_DIR}/bin"
+cp "CLI.json" "${OUTPUT_DIR}/bin" 
 
 info "Gathered dependencies in ${OUTPUT_DIR}"


### PR DESCRIPTION
CC: @jmoody 

@jonstoneman It doesn't look like there needs to be any changes in `DeploymentManager.cs`, since the `CLI.json` will just sit along side `iOSDeviceManager` in the `bin` folder. But please correct me if I'm wrong there. 
