### PR TITLE
Make: copy build/Release/CLI.json to distro bin/

### DIFF
--- a/bin/make/dependencies.sh
+++ b/bin/make/dependencies.sh
@@ -56,5 +56,6 @@ make clean
 make build
 
 cp "Products/${EXECUTABLE}" "${OUTPUT_DIR}/bin"
+cp "build/Release/CLI.json" "${OUTPUT_DIR}/bin"
 
 info "Gathered dependencies in ${OUTPUT_DIR}"


### PR DESCRIPTION
### Motivation

CLI.json is now a requirement for the iOSDeviceManager binary
