### PR TITLE
Make: copy FB Frameworks with ditto

### DIFF
--- a/bin/make/dependencies.sh
+++ b/bin/make/dependencies.sh
@@ -38,8 +38,20 @@ mkdir -p "${OUTPUT_DIR}/ipa"
 HERE=$(pwd)
 
 (cd "${FBSIMCONTROL_PATH}";
- make frameworks;
- cp -r build/Release/* "${HERE}/${OUTPUT_DIR}/Frameworks")
+make frameworks;
+
+xcrun ditto build/Release/FBControlCore.framework \
+  "${HERE}/${OUTPUT_DIR}/Frameworks/FBControlCore.framework" ;
+
+xcrun ditto build/Release/FBDeviceControl.framework \
+  "${HERE}/${OUTPUT_DIR}/Frameworks/FBDeviceControl.framework" ;
+
+xcrun ditto build/Release/FBSimulatorControl.framework \
+  "${HERE}/${OUTPUT_DIR}/Frameworks/FBSimulatorControl.framework" ;
+
+xcrun ditto build/Release/XCTestBootstrap.framework \
+  "${HERE}/${OUTPUT_DIR}/Frameworks/XCTestBootstrap.framework" ;
+)
 
 (cd "${DEVICEAGENT_PATH}";
  make app-agent;
@@ -56,6 +68,6 @@ make clean
 make build
 
 cp "Products/${EXECUTABLE}" "${OUTPUT_DIR}/bin"
-cp "CLI.json" "${OUTPUT_DIR}/bin" 
+cp "CLI.json" "${OUTPUT_DIR}/bin"
 
 info "Gathered dependencies in ${OUTPUT_DIR}"


### PR DESCRIPTION
### Motivation

I notice yesterday that the Frameworks.zip was ~12 MB and I did not userstand why.  I recalled a much smaller archive.  The copy step in `dependencies.sh` was using `cp -r` which copied all the symlinks at files.
The archive is now ~1.9 MB.

I decided to use `ditto` because the Frameworks are signed.
