### PR TITLE
Xcode: do not search user paths for headers

### DIFF
--- a/iOSDeviceManager.xcodeproj/project.pbxproj
+++ b/iOSDeviceManager.xcodeproj/project.pbxproj
@@ -958,7 +958,7 @@
 		89331D481CE222C7003C2E59 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1004,7 +1004,7 @@
 		89331D491CE222C7003C2E59 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1043,7 +1043,7 @@
 		89331D4B1CE222C7003C2E59 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1061,7 +1061,7 @@
 		89331D4C1CE222C7003C2E59 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1107,7 +1107,7 @@
 		89EF4ACF1CFA614F006DCDC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1126,7 +1126,7 @@
 		89EF4AD01CFA614F006DCDC5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
### Motivation

This is an attempt to fix the dread missing XCTBootstrap header problem.  Even if it does not fix that problem:

> If enabled both #include <header.h>-style and #include "header.h"-style directives will search the paths in "User Header Search Paths" before "Header Search Paths", with the consequence that user headers (such as your own String.h header) would have precedence over system headers when using #include <header.h>. This is done using the -iquote flag for the paths provided in "User Header Search Paths". If disabled and your compiler fully supports separate user paths, user headers will only be accessible with #include "header.h"-style preprocessor directives. For backwards compatibility reasons, this setting is enabled by default, but disabling it is strongly recommended.
