### PR TITLE
Make dependencies should not make the Facebook Frameworks

### DIFF
--- a/bin/make/dependencies.sh
+++ b/bin/make/dependencies.sh
@@ -34,6 +34,8 @@ do
   info "Copied ${framework} to ${TARGET}"
 done
 
+banner "Making DeviceAgent"
+
 (cd "${DEVICEAGENT_PATH}";
  make app-agent;
  make ipa-agent;
@@ -42,8 +44,12 @@ done
  xcrun ditto Products/app/DeviceAgent/DeviceAgent-Runner.app \
    "${OUTPUT_DIR}/app/DeviceAgent-Runner.app")
 
+banner "Copying Licenses"
+
 cp LICENSE "${OUTPUT_DIR}"
 cp vendor-licenses/* "${OUTPUT_DIR}/Frameworks"
+
+banner "Making iOSDeviceManager"
 
 make clean
 make build


### PR DESCRIPTION
### Motivation

I think we are at the point where we should be tracking the Facebook Frameworks with git commits and _not_ building them from sources every time we `make dependencies`.

This put the onus of managing the Facebook Frameworks on the iOSDeviceManager maintainers rather than folks like @jonstoneman  and @Devneval who don't know about the FBSimulatorControl stack.

If I am reading the original script correctly, the FB Frameworks are made twice, so if this PR is rejected, we should address that problem.

```
# Old workflow
1. Visit DeviceAgent.iOS and FBSimulatorControl directory and pull from master
2. Pull the latest iOSDeviceManager
3. $ make dependencies (or nuget)

# New workflow
1. Visit DeviceAgent.iOS and pull from master
2. Pull the latest iOSDeviceManager
3. $ make dependencies (or nuget)
```
