### PR TITLE
Release/1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+### 1.0.2
+
+* Update fb frameworks (rm dup ref) #68
+* Update to include frameworks from /pull/12 #67
+* Feature/daemonize update frameworks #65
+* Update FBFrameworks #64
+* FIXUP: Sign the sim app bundle with the ad hoc signature '-' #63
+* Update session-id default #61
+* Feature/daemonize add http frameworks #60
+* Update fb frameworks #59
+* Make entitlement match robust to different entitlement formats #58
+* Find usable codesign identity when not specified #53


### PR DESCRIPTION
### Motivation

I am releasing DeviceAgent 1.0.2 in run-loop.
### 1.0.2
- Update fb frameworks (rm dup ref) #68
- Update to include frameworks from /pull/12 #67
- Feature/daemonize update frameworks #65
- Update FBFrameworks #64
- FIXUP: Sign the sim app bundle with the ad hoc signature '-' #63
- Update session-id default #61
- Feature/daemonize add http frameworks #60
- Update fb frameworks #59
- Make entitlement match robust to different entitlement formats #58
- Find usable codesign identity when not specified #53
