### PR TITLE
Stabilize Jenkins builds around CocoaLumberjack

### DIFF
--- a/bin/test/ci.sh
+++ b/bin/test/ci.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+export DEVELOPER_DIR=/Xcode/8.0/Xcode.app/Contents/Developer
+
+set +e
+
+# Force Xcode 8 CoreSimulator env to be loaded so xcodebuild does not fail.
+for try in {1..4}; do
+  xcrun simctl help &>/dev/null
+  sleep 1.0
+done
+
 set -e
 
 if [ -z "${JENKINS_HOME}" ]; then
@@ -27,12 +37,8 @@ fi
 (cd "${CODE_SIGN_DIR}" && ios/create-keychain.sh)
 
 rm -rf DeviceAgent.iOS
-
 git clone git@github.com:calabash/DeviceAgent.iOS.git
-
-export DEVICEAGENT_PATH=./DeviceAgent.iOS
-
-make dependencies
+DEVICEAGENT_PATH=./DeviceAgent.iOS make dependencies
 
 set +e
 


### PR DESCRIPTION
### Motivation

Jenkins has been failing for a week or so on this error:

```
/Users/Shared/Jenkins/jobs/iOSDeviceManager PR/workspace/Carthage/Build/Mac/CocoaLumberjack.framework/Headers/DDFileLogger.h:429:40: token is not a valid binary operator in a preprocessor subexpression
#if FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST(8)
```

My best guess is that `FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST` is an Xcode 8 macro.

Can reproduce in Xcode 7.3.1 locally.

```
DEVICEAGENT_PATH=../DeviceAgent.iOS \
  DEVELOPER_DIR=/Xcode/7.3.1/Xcode.app/Contents/Developer \
  bin/make/dependencies.sh
```

Subsequent Jenkins jobs which require/expect Xcode 7.3.1 _might_ fail if they are not careful about loading the correct CoreSimulatorService before executing.  UITest and the Calabash stack are probably immune to this problem, but the new test cloud uploader probably is not.
