### PR TITLE
Fix cannot find XCTBootstrap.framework compile time errors

### DIFF
--- a/iOSDeviceManager.xcodeproj/project.pbxproj
+++ b/iOSDeviceManager.xcodeproj/project.pbxproj
@@ -1371,7 +1371,7 @@
 				);
 				GCC_PREFIX_HEADER = "";
 				GENERATE_MASTER_OBJECT_FILE = NO;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1389,7 +1389,7 @@
 				);
 				GCC_PREFIX_HEADER = "";
 				GENERATE_MASTER_OBJECT_FILE = NO;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1409,7 +1409,7 @@
 				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/Tests/Tests.pch";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Tests/UnitInfo.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.Unit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1428,7 +1428,7 @@
 				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/Tests/Tests.pch";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Tests/UnitInfo.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.Unit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1446,7 +1446,7 @@
 				);
 				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/Tests/Tests.pch";
 				INFOPLIST_FILE = Tests/IntegrationInfo.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.Integration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1464,7 +1464,7 @@
 				);
 				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/Tests/Tests.pch";
 				INFOPLIST_FILE = Tests/IntegrationInfo.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.Integration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
### Motivation

Completes:

- iOSDeviceManager does not build without a clean (intermittent) [TCFW-741](https://jira.xamarin.com/browse/TCFW-741)

### Notes

iOSDeviceManager Copy Files was not copying the frameworks to a `Frameworks/` directory despite the "Frameworks" item being selected.  This is because iOSDeviceManager is a command line tool - there is no application bundle to for Frameworks directory to live.

The Run Search Path should not contain references to the FRAMEWORKS_SEARCH_PATH - this change was recently made - probably to fix compile time problems associated with add the CocoaLumberjack.framework. 

> The Unit and Integration tests probably do not need copy the Frameworks at all.

This is incorrect.  The Unit and Integration tests _do_ need to copy the Frameworks to their bundle.  I made this observation early and I was wrong.