### PR TITLE
Stores identities rather than making multiple find-identity calls

### DIFF
--- a/iOSDeviceManager/Utilities/CodesignIdentity.m
+++ b/iOSDeviceManager/Utilities/CodesignIdentity.m
@@ -29,7 +29,7 @@
         return nil;
     }
     
-    NSArray <CodesignIdentity *>* identities = [self validIOSDeveloperIdentities];
+    NSArray <CodesignIdentity *>* identities = [CodesignIdentity validIOSDeveloperIdentities];
     if (!identities) {
         return nil;
     }


### PR DESCRIPTION
**Motivation** 

Reduce the number of redundant calls to 
```@[@"security", @"find-identity", @"-v", @"-p", @"codesigning"];```
Previously this call was made 3 times now just 2 times. We could add a static var to hold the results of the first call to
```[CodesignIdentity validIOSDeveloperIdentities]```
for further improvement - but I wasn't sure if that was desired behavior for that method so figured I would ask first.

https://jira.xamarin.com/browse/TCFW-849

cc: @jmoody 