### PR TITLE
PhysicalDevice: don't branch on non-nil NSError instance

### DIFF
--- a/iOSDeviceManager/Devices/PhysicalDevice.m
+++ b/iOSDeviceManager/Devices/PhysicalDevice.m
@@ -49,13 +49,12 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
     FBDevice *fbDevice = [[FBDeviceSet defaultSetWithLogger:nil
                                                     error:&err]
                                             deviceWithUDID:uuid];
-    if (!fbDevice || err) {
+    if (!fbDevice) {
         ConsoleWriteErr(@"Error getting device with ID %@: %@", uuid, err);
         return nil;
     }
 
-    [fbDevice.deviceOperator waitForDeviceToBecomeAvailableWithError:&err];
-    if (err) {
+    if (![fbDevice.deviceOperator waitForDeviceToBecomeAvailableWithError:&err]) {
         ConsoleWriteErr(@"Error getting device with ID %@: %@", uuid, err);
         return nil;
     }
@@ -120,7 +119,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
     }
     
     FBiOSDeviceOperator *op = self.fbDevice.deviceOperator;
-    if ([op isApplicationInstalledWithBundleID:codesignedApp.bundleID error:&err] || err) {
+    if ([op isApplicationInstalledWithBundleID:codesignedApp.bundleID error:&err]) {
         if (err) {
             ConsoleWriteErr(@"Error checking if app {%@} is installed. %@", codesignedApp.bundleID, err);
             return iOSReturnStatusCodeInternalError;
@@ -131,7 +130,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
             return ret;
         }
     } else {
-        if (![op installApplicationWithPath:stagedApp error:&err] || err) {
+        if (![op installApplicationWithPath:stagedApp error:&err]) {
             ConsoleWriteErr(@"Error installing application: %@", err);
             return iOSReturnStatusCodeInternalError;
         }
@@ -184,7 +183,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
         return iOSReturnStatusCodeInternalError;
     }
     
-    if (![op cleanApplicationStateWithBundleIdentifier:bundleID error:&err] || err) {
+    if (![op cleanApplicationStateWithBundleIdentifier:bundleID error:&err]) {
         ConsoleWriteErr(@"Error uninstalling app %@: %@", bundleID, err);
     }
     
@@ -298,7 +297,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
 
 - (Application *)installedApp:(NSString *)bundleID {
     NSError *err;
-    if (![self isInstalled:bundleID withError:err] || err) {
+    if (![self isInstalled:bundleID withError:err]) {
         return nil;
     }
 


### PR DESCRIPTION
### Motivation

Branch on the return value of the method instead.

I noticed these examples while debugging failing tests.

### Tests

Tested on macOS Sierra with Xcode 8.2.1.

- [x] make test-unit
- [x] make test-integration (2 Failing)
- [x] make test-run-loop

The two failing integration tests are captured in Jira and appear to be unrelated to these changes.

* MobileProfileTest : testRankedIOSProfilesForResigning fails [TCFW-1043](https://jira.xamarin.com/browse/TCFW-1043)
* SimulatorCLIIntegrationTests : testLaunchAndKillApp fails if more than one physical device is installed [TCFW-1044](https://jira.xamarin.com/browse/TCFW-1044)