### PR TITLE
Adds support for icloud-services wildcard entitlements

### DIFF
--- a/iOSDeviceManager/Resigning/Codesigner.m
+++ b/iOSDeviceManager/Resigning/Codesigner.m
@@ -367,8 +367,12 @@ static NSString *const IDMCodeSignErrorDomain = @"sh.calaba.iOSDeviceManger";
     NSString *appId = [appDirName subsFrom:0 length:appDirName.length - @".app".length];
     NSString *xcentFilename = [appId plus:@".xcent"];
     NSString *appEntitlementsFile = [appDir joinPath:xcentFilename];
-    
-    Entitlements *finalEntitlements = [newEntitlements entitlementsByReplacingApplicationIdentifier:finalAppIdentifier];
+
+    // Check entitlements for Cloud Kit
+    id originaliCloudServicesEntitlement = oldEntitlements[@"com.apple.developer.icloud-services"];
+    Entitlements *entitlementsWithICloudServices = [newEntitlements entitlementsByReplacingiCloudServicesWildcard:originaliCloudServicesEntitlement];
+
+    Entitlements *finalEntitlements = [entitlementsWithICloudServices entitlementsByReplacingApplicationIdentifier:finalAppIdentifier];
     NSString *newTeamId = finalEntitlements[@"com.apple.developer.team-identifier"];
     
     success = [mgr fileExistsAtPath:bundleExecPath];

--- a/iOSDeviceManager/Resigning/Entitlements.h
+++ b/iOSDeviceManager/Resigning/Entitlements.h
@@ -21,5 +21,7 @@
 
 // Required during the code signing to generate a new .xcent file.
 - (Entitlements *)entitlementsByReplacingApplicationIdentifier:(NSString *)applicationIdentifier;
+// Prevent CKException when using wildcard entitlement for icloud-services
+- (Entitlements *)entitlementsByReplacingiCloudServicesWildcard:(id)appEntitlementValue;
 
 @end

--- a/iOSDeviceManager/Resigning/Entitlements.m
+++ b/iOSDeviceManager/Resigning/Entitlements.m
@@ -142,6 +142,16 @@
     return self.dictionary[key] ?: nil;
 }
 
+- (Entitlements *)entitlementsByReplacingiCloudServicesWildcard:(id)appEntitlementValue {
+    NSMutableDictionary *mutable = [self.dictionary mutableCopy];
+    if ([mutable[@"com.apple.developer.icloud-services"] isEqualToString:@"*"]) {
+        mutable[@"com.apple.developer.icloud-services"] = appEntitlementValue;
+        return [Entitlements entitlementsWithDictionary:mutable];
+    } else {
+        return self;
+    }
+}
+
 - (Entitlements *)entitlementsByReplacingApplicationIdentifier:(NSString *)applicationIdentifier {
     NSMutableDictionary *mutable = [self.dictionary mutableCopy];
     mutable[@"application-identifier"] = applicationIdentifier;


### PR DESCRIPTION
**Motivation**
A provisioning profile with the entitlement and value `"com.apple.developer.icloud-services": "*"` should be able to sign an application with the entitlement and value `"com.apple.developer.icloud-services": ["CloudKit"]`. But currently you'll run into a crash after launching the resigned app, namely:
`
*** Terminating app due to uncaught exception 'CKException', reason: 'The application is missing required entitlement com.apple.developer.icloud-services'.`

Is this something we'll be able to do on Test Cloud? Also, if we want this fix - is there a particular app I should write a test for? 