### PR TITLE
Device#startTest: returns nil or FBTestManager

### DIFF
--- a/iOSDeviceManager/Devices/PhysicalDevice.m
+++ b/iOSDeviceManager/Devices/PhysicalDevice.m
@@ -331,7 +331,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
     }
 
     LogInfo(@"Starting test with SessionID: %@, DeviceID: %@, runnerBundleID: %@", sessionID, [self uuid], runnerID);
-    NSError *e = nil;
+    NSError *error = nil;
 
     FBTestManager *testManager = [FBXCTestRunStrategy startTestManagerForIOSTarget:self.fbDevice
                                                                     runnerBundleID:runnerID
@@ -340,22 +340,22 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
                                                                        environment:[FBTestRunnerConfigurationBuilder defaultBuildEnvironment]
                                                                           reporter:self
                                                                             logger:self
-                                                                             error:&e];
-    if (!e) {
-        if (keepAlive) {
-            /*
-             `testingComplete` will be YES when testmanagerd calls
-             `testManagerMediatorDidFinishExecutingTestPlan:`
-             */
-
-            FBRunLoopSpinner *spinner = [FBRunLoopSpinner new];
-            [spinner spinUntilTrue:^BOOL () {
-                return ([testManager testingHasFinished] && self.testingComplete);
-            }];
-        }
-    } else {
-        ConsoleWriteErr(@"Err: %@", e);
+                                                                             error:&error];
+    if (!testManager) {
+        ConsoleWriteErr(@"Could not start test: %@", error);
         return iOSReturnStatusCodeInternalError;
+    } else
+
+    if (keepAlive) {
+        /*
+         `testingComplete` will be YES when testmanagerd calls
+         `testManagerMediatorDidFinishExecutingTestPlan:`
+         */
+
+        FBRunLoopSpinner *spinner = [FBRunLoopSpinner new];
+        [spinner spinUntilTrue:^BOOL () {
+            return ([testManager testingHasFinished] && self.testingComplete);
+        }];
     }
     return iOSReturnStatusCodeEverythingOkay;
 }

--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -346,7 +346,6 @@ static const FBSimulatorControl *_control;
 - (iOSReturnStatusCode)startTestWithRunnerID:(NSString *)runnerID
                                    sessionID:(NSUUID *)sessionID
                                    keepAlive:(BOOL)keepAlive {
-
     NSError *error = nil;
     if (![self bootSimulatorIfNecessary:&error]) {
         ConsoleWriteErr(@"Failed to boot sim: %@", error);
@@ -368,8 +367,7 @@ static const FBSimulatorControl *_control;
                                                                           reporter:replog
                                                                             logger:replog
                                                                              error:&error];
-
-    if (error) {
+    if (!testManager) {
         ConsoleWriteErr(@"Error starting test runner: %@", error);
         return iOSReturnStatusCodeInternalError;
     } else if (keepAlive) {


### PR DESCRIPTION
**REBASED:** Wed Mar 17:48 CET

Requires:

* Update facebook frameworks to bf0f6ef: part 2 of 2 frameworks changes #129

### Motivation

Previously, this method return FBTestManager instance on success and and NSError subclass on failure.  The returned NSError was not consumed by the callers, instead the NSError passed by reference was consumed which means that all the extra context provided by the returned XCTestBootstrapError was never displayed to the user.

Now #startTest returns nil on failure and correct sets the NSError reference with the XCTestBootstrapError (for extra context).   The callers branch on nil FBTestManager and on error report the XCTestBootstrapError.

### Tests

Expect tests to fail with compile errors until rebased against #129 

Tests are not expected to pass on Xcode 8.3.

- [x] El Cap
    - [x] Xcode 8.2.1
      - [x] make test-unit
      - [x] make test-integration
      - [x] make test-run-loop
- [x] Sierra
    - [x] Xcode 8.2.1
      - [x] make test-unit
      - [x] make test-integration
      - [x] make test-run-loop
