### PR TITLE
Simulator#launch: wait for required simulator sevices

### DIFF
--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -74,8 +74,9 @@ static const FBSimulatorControl *_control;
     FBSimulatorState state = self.fbSimulator.state;
     if (state == FBSimulatorStateShutdown || state == FBSimulatorStateShuttingDown) {
 
+        FBSimulatorBootOptions options = FBSimulatorBootOptionsConnectBridge | FBSimulatorBootOptionsAwaitServices;
         FBSimulatorBootConfiguration *bootConfig;
-        bootConfig = [FBSimulatorBootConfiguration withOptions:FBSimulatorBootOptionsConnectBridge];
+        bootConfig = [FBSimulatorBootConfiguration withOptions:options];
 
         FBSimulatorLifecycleCommands *lifecycleCommands;
         lifecycleCommands = [Simulator lifecycleCommandsWithFBSimulator:self.fbSimulator];


### PR DESCRIPTION
**Expect Rebase**

Requires:

* Update facebook frameworks to bf0f6ef: part 2 of 2 frameworks changes #129

### Motivation

FBSimulatorBootOptions allow iOSDeviceManager to wait for the simulator to fully boot by using the `FBSimulatorBootOptionsAwaitService` option.

Run-loop has being doing something similar since the introduction of CoreSimulator.   Waiting for the simulator to be fully booted helps avoid incomplete application installations - a reproducible problem on iPad simulators in Xcode 7.   Run-loop has adopted the _same approach as FBSimulatorControl_ (i.e. waits for the same processes). 

### Related

* Don't wait for 'medialibraryd' when booting iOS 8 devices [#371](https://github.com/facebook/FBSimulatorControl/pull/371)
* FBSimulatorBootStrategy: don't wait for medialibraryd on iOS < 9 [#393](https://github.com/facebook/FBSimulatorControl/pull/393)

### Tests

Tests will fail with compile errors until #129 is merged.

Tests are expected to fail on Xcode 8.3

- [x] El Cap
    - [x] Xcode 8.2.1
      - [x] make test-unit
      - [x] make test-integration
      - [x] make test-run-loop
- [x] Sierra
    - [x] Xcode 8.2.1
      - [x] make test-unit
      - [x] make test-integration
      - [x] make test-run-loop
