### PR TITLE
Simulator#launch:  simplify computing the return value

### DIFF
--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -75,7 +75,7 @@ static const FBSimulatorControl *_control;
         }
     }
 
-    return self.fbSimulator != nil ? iOSReturnStatusCodeEverythingOkay : iOSReturnStatusCodeDeviceNotFound;
+    return iOSReturnStatusCodeEverythingOkay;
 }
 
 - (iOSReturnStatusCode)kill {


### PR DESCRIPTION
### Motivation

If self.fbSimulator is nil, this method should fail in the previous `if` branch.

### Tests

### Tests

- [ ] El Cap
    - [ ] Xcode 8.2.1
      - [ ] make test-unit
      - [ ] make test-integration
      - [ ] make test-run-loop
    - [ ] Xcode 8.3
      - [ ] make test-unit
      - [ ] make test-integration
      - [ ] make test-run-loop
- [ ] Sierra
    - [ ] Xcode 8.2.1
      - [ ] make test-unit
      - [ ] make test-integration
      - [ ] make test-run-loop
    - [ ] Xcode 8.3
      - [ ] make test-unit
      - [ ] make test-integration
      - [ ] make test-run-loop