### PR TITLE
Adds shared integration tests

### DIFF
--- a/Tests/Integration/DeviceCLIIntegrationTests.h
+++ b/Tests/Integration/DeviceCLIIntegrationTests.h
@@ -1,0 +1,72 @@
+#import <XCTest/XCTest.h>
+#import "TestUtils.h"
+#import "CLI.h"
+
+/*
+ A class to extract common util functions of PhysicalDevices and Simulators.
+
+ No `test*` methods should exist here directly, but but common `test*` methods
+ can have their implementation extracted here.
+ */
+
+@interface DeviceCLIIntegrationTests : XCTestCase
+@property (nonatomic, strong) NSString *deviceID;
+@property (nonatomic, strong) NSString *platform; //ARM or SIM
+@property (nonatomic, strong) NSString *codesignID;
+@property(strong, readonly) Resources *resources;
+
+/*
+ Uninstalls app if installed. Asserts that app is not installed before returning.
+ */
+- (void)uninstallOrThrow:(NSString *)bundleID;
+
+/*
+ Installs if not installed. Asserts that app is installed before returning.
+ */
+- (void)installOrThrow:(NSString *)appPath bundleID:(NSString *)bundleID shouldUpdate:(BOOL)shouldUpdate;
+
+/*
+ YES if installed, NO if not, throws if error occurs when checking.
+ */
+- (BOOL)isInstalled:(NSString *)bundleID;
+
+/*
+ Returns CFBundleIdentifier
+ */
+- (NSString *)appBundleVersion:(NSString *)bundleID;
+
+/*
+ Calls start_test with -K NO so that it doesn't hang.
+ TODO: -k YES, sleep, POST 1.0/shutdown, assert success
+ */
+- (iOSReturnStatusCode)startTest;
+
+
+- (iOSReturnStatusCode)setLocation:(NSString *)location;
+
+/*
+ Shared tests
+
+ These are written in an architecture agnostic way. Any arch-specific code can be handled
+ by the setUp method.
+
+ For naming conventions, if the original test is
+ - (void)testFooBarBaz
+
+ the shared test should be
+ - (void)sharedFooBarBazTest
+
+ s'il vous plait.
+
+ */
+- (void)sharedInstallTest;
+- (void)sharedUninstallTest;
+- (void)sharedAppUpdateTest;
+- (void)sharedUploadFileTest;
+- (void)sharedSetLocationTest;
+- (void)sharedOptionalArgsTest;
+- (void)sharedAppIsInstalledTest;
+- (void)sharedPositionalArgsTest;
+- (void)sharedLaunchAndKillAppTest;
+- (void)sharedStopSimulatingLocationTest;
+@end

--- a/Tests/Integration/DeviceCLIIntegrationTests.m
+++ b/Tests/Integration/DeviceCLIIntegrationTests.m
@@ -1,0 +1,330 @@
+
+#import "DeviceCLIIntegrationTests.h"
+
+@interface DeviceCLIIntegrationTests()
+
+@end
+
+@implementation DeviceCLIIntegrationTests
+
+- (void)setUp {
+    [[Resources shared] setDeveloperDirectory];
+    [Simctl shared];
+
+    XCTAssertNotNil(self.platform, @"Must set a platform");
+    XCTAssertNotNil(self.codesignID, @"Must set a codesigning identity");
+    XCTAssertNotNil(self.deviceID, @"Must set a device identifier");
+
+    [super setUp];
+}
+
+- (Resources *)resources {
+    return [Resources shared];
+}
+
+- (NSString *)appBundleVersion:(NSString *)bundleID {
+    NSDictionary *plist;
+    plist = [[Device withID:self.deviceID] installedApp:bundleID].infoPlist;
+    return plist[@"CFBundleVersion"];
+}
+
+- (BOOL)isInstalled:(NSString *)bundleID {
+    NSArray *args = @[
+                      kProgramName, @"is_installed",
+                      @"-b", bundleID,
+                      @"-d", self.deviceID
+                      ];
+    iOSReturnStatusCode installedRC = [CLI process:args];
+
+    XCTAssertTrue(installedRC == iOSReturnStatusCodeFalse ||
+                  installedRC == iOSReturnStatusCodeEverythingOkay,
+                  @"Error checking if %@ is installed on %@", bundleID, self.deviceID);
+    return installedRC == iOSReturnStatusCodeFalse ? NO : YES;
+}
+
+- (void)uninstallOrThrow:(NSString *)bundleID {
+    if ([self isInstalled:bundleID]) {
+        NSArray *args = @[
+                          kProgramName, @"uninstall",
+                          @"-d", self.deviceID,
+                          @"-b", bundleID
+                          ];
+        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    }
+    XCTAssertFalse([self isInstalled:bundleID]);
+}
+
+- (void)installOrThrow:(NSString *)appPath bundleID:(NSString *)bundleID shouldUpdate:(BOOL)shouldUpdate {
+    NSArray *args = @[kProgramName, @"install",
+                      @"-d", self.deviceID,
+                      @"-c", self.codesignID,
+                      @"-a", appPath,
+                      @"-u", shouldUpdate ? @"YES" : @"NO"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    XCTAssertTrue([self isInstalled:bundleID]);
+}
+
+- (iOSReturnStatusCode)startTest {
+    NSArray *args = @[kProgramName, @"start_test",
+                      @"-d", self.deviceID,
+                      @"-k", @"NO"];
+    return [CLI process:args];
+}
+
+- (iOSReturnStatusCode)setLocation:(NSString *)location {
+    NSArray *args = @[kProgramName, @"set_location", @"-d", self.deviceID, @"-l", location];
+    return [CLI process:args];
+}
+
+#pragma mark - Shared Tests
+- (void)sharedInstallTest {
+    //Ensure app isn't installed
+    [self uninstallOrThrow:taskyAppID];
+
+    //Test absolute path install
+    [self installOrThrow:tasky(self.platform) bundleID:taskyAppID shouldUpdate:NO];
+    [self uninstallOrThrow:testAppID];
+
+    //Test relative path install
+    [self installOrThrow:[self.resources TestAppRelativePath:self.platform]
+                bundleID:testAppID shouldUpdate:NO];
+}
+
+- (void)sharedUninstallTest {
+    //Ensure app isn't installed
+    [self uninstallOrThrow:testAppID];
+
+    //Install it
+    [self installOrThrow:[self.resources TestAppPath:self.platform] bundleID:testAppID shouldUpdate:NO];
+
+    //Ensure it can be uninstalled
+    [self uninstallOrThrow:testAppID];
+}
+
+- (void)sharedAppIsInstalledTest {
+    //Sanity check: settings app should always be installed
+    XCTAssertTrue([self isInstalled:@"com.apple.Preferences"]);
+
+    [self uninstallOrThrow:testAppID];
+    XCTAssertFalse([self isInstalled:testAppID]); //redundant but just for clarity
+
+    [self installOrThrow:testApp(self.platform) bundleID:testAppID shouldUpdate:NO];
+    XCTAssertTrue([self isInstalled:testAppID]); //also redundant, also for clarity
+}
+
+- (void)sharedUploadFileTest {
+    [self uninstallOrThrow:testAppID];
+    [self installOrThrow:testApp(self.platform) bundleID:testAppID shouldUpdate:NO];
+
+    //Upload a unique file
+    NSString *file = uniqueFile();
+    NSArray *args = @[
+                      kProgramName, @"upload",
+                      @"-b", testAppID,
+                      @"-d", self.deviceID,
+                      @"-f", file,
+                      @"-o", @"NO"
+                      ];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    //Now attempt to overwrite with -o false
+    args = @[
+             kProgramName, @"upload",
+             @"-b", testAppID,
+             @"-d", self.deviceID,
+             @"-f", file,
+             @"-o", @"NO"
+             ];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
+
+    //Now attempt to overwrite with -o true
+    args = @[
+             kProgramName, @"upload",
+             @"-b", testAppID,
+             @"-d", self.deviceID,
+             @"-f", file,
+             @"-o", @"YES"
+             ];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)sharedAppUpdateTest {
+    //Ensure app is not installed
+    [self uninstallOrThrow:testAppID];
+
+    //Set app's info.plist CFBundleVersion to 1.0
+    NSString *tmpDir = [self.resources uniqueTmpDirectory];
+    NSString *source = testApp(self.platform);
+    NSString *target = [tmpDir stringByAppendingPathComponent:[source lastPathComponent]];
+    [self.resources copyDirectoryWithSource:source target:target];
+
+    XCTAssertTrue([self.resources updatePlistForBundle:target
+                                                   key:@"CFBundleVersion"
+                                                 value:@"1.0"]);
+
+    [self installOrThrow:target bundleID:testAppID shouldUpdate:NO];
+
+    //Ensure that the installed app has CFBundleVersion 1.0
+    NSString *installedVersion = [self appBundleVersion:testAppID];
+    XCTAssertEqualObjects(installedVersion, @"1.0",
+                          @"Installed app's Info.plist doesn't match");
+
+    //Now update the local plist to have CFBundleVersion 2.0
+    XCTAssertTrue([self.resources updatePlistForBundle:target
+                                                   key:@"CFBundleVersion"
+                                                 value:@"2.0"]);
+
+    //Install the app and ensure that the new version has been installed
+    [self installOrThrow:target bundleID:testAppID shouldUpdate:YES];
+
+    installedVersion = [self appBundleVersion:testAppID];
+    XCTAssertEqualObjects(installedVersion, @"2.0",
+                          @"Installed app's Info.plist doesn't match");
+
+
+    //Now change it back to 1.0 and try to install while setting `-u` to false.
+    //We should see that the installed version remains at 2.0
+    XCTAssertTrue([self.resources updatePlistForBundle:target
+                                                   key:@"CFBundleVersion"
+                                                 value:@"1.0"]);
+
+    [self installOrThrow:target bundleID:testAppID shouldUpdate:NO];
+
+    installedVersion = [self appBundleVersion:testAppID];
+    XCTAssertEqualObjects(installedVersion, @"2.0",
+                          @"App was updated even though -u was set to NO");
+}
+
+- (void)sharedLaunchAndKillAppTest {
+    [self installOrThrow:testApp(self.platform) bundleID:testAppID shouldUpdate:NO];
+
+    NSArray *args = @[kProgramName, @"launch_app", self.deviceID, @"-b", testAppID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    //TODO: Verify app is running
+
+    args = @[kProgramName, @"kill_app", self.deviceID, @"-b", testAppID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)sharedSetLocationTest {
+    //Should fail: invalid coordinates
+    XCTAssertEqual([self setLocation:@"banana"], iOSReturnStatusCodeInvalidArguments);
+
+    //Should pass: Stockholm coordinates point to a real place.
+    XCTAssertEqual([self setLocation:kStockholmCoord], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)sharedOptionalArgsTest {
+    //Start from clean slate
+    [self uninstallOrThrow:testAppID];
+    NSString *relativeAppPath = [self.resources TestAppRelativePath:self.platform];
+    NSArray *args;
+
+    /*
+     $ idm install relative/path/to/app
+     */
+    args = @[kProgramName, @"install", relativeAppPath];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $ idm install absolute/path/to/app
+     */
+    args = @[kProgramName, @"install", testApp(self.platform)];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $ idm start_test <device_id> <test_runner_bundle_id>
+     */
+    [self installOrThrow:runner(self.platform) bundleID:kDeviceAgentBundleID shouldUpdate:NO];
+    args = @[kProgramName, @"start_test", self.deviceID, kDeviceAgentBundleID, @"-k", @"NO"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    /*
+     $ idm start_test <device_id>
+     */
+    args = @[kProgramName, @"start_test", self.deviceID, @"-k", @"NO"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    /*
+     $ idm start_test <test_runner_bundle_id>
+     */
+    args = @[kProgramName, @"start_test", kDeviceAgentBundleID, @"-k", @"NO"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    /*
+     $ idm start_test
+     */
+    args = @[kProgramName, @"start_test", @"-k", @"NO"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)sharedStopSimulatingLocationTest {
+    NSArray *args = @[
+                      kProgramName, @"stop_simulating_location",
+                      @"-d", self.deviceID
+                      ];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)sharedPositionalArgsTest {
+    //Start from a clean slate.
+    [self uninstallOrThrow:testAppID];
+    NSString *relativeAppPath = [self.resources TestAppRelativePath:self.platform];
+    NSArray *args;
+
+    /*
+     $idm install absolute/path/to/app device_id
+     */
+    args = @[kProgramName, @"install", testApp(self.platform), self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $idm install device_id absolute/path/to/app
+     */
+    args = @[kProgramName, @"install", self.deviceID, testApp(self.platform)];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $idm install relative/path/to/app device_id
+     */
+    args = @[kProgramName, @"install", relativeAppPath, self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $ idm install device_id relative/path/to/app
+     */
+    args = @[kProgramName, @"install", self.deviceID, relativeAppPath];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self uninstallOrThrow:testAppID];
+
+
+    /*
+     $ idm install <app_path> => missing args
+     */
+    args = @[kProgramName, @"install", self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeMissingArguments);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $ idm install <non_existant_app_path> => missing args
+     */
+    args = @[kProgramName, @"install", self.deviceID, testApp(self.platform), @"-a", @"/path/to/another/app"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
+    [self uninstallOrThrow:testAppID];
+
+    /*
+     $ idm install <device_id> <app_path> -d <another_device_id> => invalid args
+     */
+    args = @[kProgramName, @"install", self.deviceID, testApp(self.platform), @"-d", self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
+    [self uninstallOrThrow:testAppID];
+}
+
+@end

--- a/Tests/Integration/PhysicalCLIDeviceIntegrationTests.m
+++ b/Tests/Integration/PhysicalCLIDeviceIntegrationTests.m
@@ -1,272 +1,82 @@
 
-#import "TestCase.h"
-#import "CLI.h"
-#import "DeviceUtils.h"
+#import "DeviceCLIIntegrationTests.h"
 
-@interface PhysicalDeviceCLIIntegrationTests : TestCase
-
+@interface PhysicalDeviceCLIIntegrationTests : DeviceCLIIntegrationTests
 @end
 
 @implementation PhysicalDeviceCLIIntegrationTests
 
 - (void)setUp {
+    self.deviceID = defaultDeviceUDID;
+    self.codesignID = kCodeSignIdentityKARL;
+    self.platform = ARM;
+
     [super setUp];
 }
 
-/* Hangs indefinitely until a POST 1.0/shutdown is received
 - (void)testStartTest {
     if (device_available()) {
-        NSArray *args = @[
-                kProgramName, @"start_test",
-                @"-d", defaultDeviceUDID,
-                @"-k", @"YES"
-        ];
-
-        [CLI process:args];
+        [self installOrThrow:runner(self.platform) bundleID:kDeviceAgentBundleID shouldUpdate:NO];
+        XCTAssertEqual([self startTest], iOSReturnStatusCodeEverythingOkay);
     }
 }
-*/
-
 
 - (void)testSetLocation {
     if (device_available()) {
-        //Should fail: invalid coordinates
-        NSArray *args = @[
-                          kProgramName, @"set_location",
-                          @"-d", defaultDeviceUDID,
-                          @"-l", @"Banana"
-                          ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
-
-        args = @[
-                 kProgramName, @"set_location",
-                 @"-d", defaultDeviceUDID, @"-l",
-                 kStockholmCoord
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedSetLocationTest];
     }
 }
 
 - (void)testStopSimulatingLocation {
     if (device_available()) {
-        NSArray *args = @[
-                          kProgramName, @"stop_simulating_location",
-                          @"-d", defaultDeviceUDID
-                          ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedStopSimulatingLocationTest];
     }
 }
 
 - (void)testUninstall {
     if (device_available()) {
-        NSArray *args = @[
-                          kProgramName, @"is_installed",
-                          @"-b", testAppID,
-                          @"-d", defaultDeviceUDID
-                          ];
-        if ([CLI process:args] == iOSReturnStatusCodeFalse) {
-            args = @[kProgramName, @"install",
-                     @"-d", defaultDeviceUDID,
-                     @"-a", testApp(ARM),
-                     @"-c", kCodeSignIdentityKARL];
-            XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        }
-
-        args = @[
-                 kProgramName, @"uninstall",
-                 @"-d", defaultDeviceUDID,
-                 @"-b", testAppID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedUninstallTest];
     }
 }
 
 - (void)testInstall {
     if (device_available()) {
-            NSArray *args = @[
-                              kProgramName, @"is_installed",
-                              @"-b", testAppID,
-                              @"-d", defaultDeviceUDID
-                              ];
-            
-            if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-                args = @[
-                         kProgramName, @"uninstall",
-                         @"-d", defaultDeviceUDID,
-                         @"-b", testAppID
-                         ];
-                XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-            }
-            
-            args = @[
-                     kProgramName, @"install",
-                     @"-d", defaultDeviceUDID,
-                     @"-a", testApp(ARM),
-                     @"-c", kCodeSignIdentityKARL
-                     ];
-            XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedInstallTest];
     }
 }
 
 - (void)testAppIsInstalled {
     if (device_available()) {
-        NSArray *args = @[
-                          kProgramName, @"is_installed",
-                          @"-b", @"com.apple.Preferences",
-                          @"-d", defaultDeviceUDID
-                          ];
-
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-        args = @[
-                 kProgramName, @"is_installed",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID
-                 ];
-
-        if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-            args = @[
-                     kProgramName, @"uninstall",
-                     @"-d", defaultDeviceUDID,
-                     @"-b", testAppID
-                     ];
-            XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        }
-
-        args = @[
-                 kProgramName, @"is_installed",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeFalse);
-
-        args = @[
-                 kProgramName, @"install",
-                 @"-d", defaultDeviceUDID,
-                 @"-a", testApp(ARM),
-                 @"-c", kCodeSignIdentityKARL
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-        args = @[
-                 kProgramName, @"is_installed",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedAppIsInstalledTest];
     }
 }
 
 - (void)testUploadFile {
     if (device_available()) {
-        //Ensure app installed
-        NSArray *args = @[
-                          kProgramName, @"is_installed",
-                          @"-b", testAppID,
-                          @"-d", defaultDeviceUDID
-                          ];
-        
-        if ([CLI process:args] == iOSReturnStatusCodeFalse) {
-            args = @[
-                     kProgramName, @"install",
-                     @"-d", defaultDeviceUDID,
-                     @"-a", testApp(ARM),
-                     @"-c", kCodeSignIdentityKARL
-                     ];
-            XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        }
-        
-        //Upload a unique file
-        NSString *file = uniqueFile();
-        args = @[
-                 kProgramName, @"upload",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID,
-                 @"-f", file,
-                 @"-o", @"NO"
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        
-        //Now attempt to overwrite with -o false
-        args = @[
-                 kProgramName, @"upload",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID,
-                 @"-f", file,
-                 @"-o", @"NO"
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
-        
-        //Now attempt to overwrite with -o true
-        args = @[
-                 kProgramName, @"upload",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID,
-                 @"-f", file,
-                 @"-o", @"YES"
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedUploadFileTest];
+    }
+}
+
+- (void)testPositionalArgs {
+    if (device_available()) {
+        [self sharedPositionalArgsTest];
     }
 }
 
 - (void)testOptionalDeviceIDArg {
-    
-    NSUInteger deviceCount = [DeviceUtils availableDevices].count;
+
+    NSUInteger deviceCount = [DeviceUtils availablePhysicalDevices].count;
     if (deviceCount != 1) {
         printf("Multiple devices detected - skipping option device arg test");
         return;
     }
-    
-    NSArray *args = @[
-                      kProgramName, @"is_installed",
-                      @"-b", testAppID
-                      ];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[
-                 kProgramName, @"uninstall",
-                 @"-b", testAppID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[
-             kProgramName, @"install",
-             @"-a", testApp(ARM),
-             @"-c", kCodeSignIdentityKARL
-             ];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    [self sharedOptionalArgsTest];
 }
 
 - (void)testLaunchAndKillApp {
     if (device_available()) {
-        NSArray *args = @[
-                          kProgramName, @"is_installed",
-                          @"-b", testAppID,
-                          @"-d", defaultDeviceUDID
-                          ];
-        
-        if ([CLI process:args] == iOSReturnStatusCodeFalse) {
-            args = @[
-                     kProgramName, @"install",
-                     @"-a", testApp(ARM),
-                     @"-d", defaultDeviceUDID
-                     ];
-            XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        }
-        
-        args = @[
-                 kProgramName, @"launch_app",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-        
-        args = @[
-                 kProgramName, @"kill_app",
-                 @"-b", testAppID,
-                 @"-d", defaultDeviceUDID
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+        [self sharedLaunchAndKillAppTest];
     }
 }
 

--- a/Tests/Integration/SimulatorCLIIntegrationTests.m
+++ b/Tests/Integration/SimulatorCLIIntegrationTests.m
@@ -1,361 +1,109 @@
 
-#import "TestCase.h"
-#import "Device.h"
-#import "CLI.h"
-#import "DeviceUtils.h"
+#import "DeviceCLIIntegrationTests.h"
 
-@interface CLI (priv)
-@end
-
-@implementation CLI (priv)
-@end
-
-
-@interface SimulatorCLIIntegrationTests : TestCase
-
-- (NSString *)bundleVersionForInstalledTestApp;
-
+@interface SimulatorCLIIntegrationTests : DeviceCLIIntegrationTests
 @end
 
 @implementation SimulatorCLIIntegrationTests
 
 - (void)setUp {
     self.continueAfterFailure = NO;
+    self.deviceID = defaultSimUDID;
+    self.codesignID = @"-"; //ad hoc
+    self.platform = SIM;
+
+    [self launchSim];
     [super setUp];
 }
 
-- (NSString *)bundleVersionForInstalledTestApp {
-    NSDictionary *plist;
-    plist = [[Device withID:defaultSimUDID] installedApp:testAppID].infoPlist;
-    return plist[@"CFBundleVersion"];
+- (void)tearDown {
+    [self killSim];
+    [super tearDown];
+}
+
+- (void)killSim {
+    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)launchSim {
+    NSArray *args = @[kProgramName, @"launch_simulator", @"-d", self.deviceID];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+}
+
+- (void)testSanity {
+    //Just ensures that sim can be launched and killed via setUp/tearDown
 }
 
 - (void)testSetLocation {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self killSim];
 
-    //Should fail: device is dead
-    args = @[kProgramName, @"set_location", @"-d", defaultSimUDID, @"-l", kStockholmCoord];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
+    //Should fail: Even though coord is valid, device is dead
+    XCTAssertEqual([self setLocation:kStockholmCoord], iOSReturnStatusCodeGenericFailure);
 
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self launchSim];
+    [self sharedSetLocationTest];
+}
 
-    //Should fail: invalid coordinates
-    args = @[kProgramName, @"set_location", @"-d", defaultSimUDID, @"-l", @"Banana"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
-
-    args = @[kProgramName, @"set_location", @"-d", defaultSimUDID, @"-l", kStockholmCoord];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+- (void)testStopSimulatingLocation {
+    [self sharedStopSimulatingLocationTest];
 }
 
 - (void)testLaunchSim {
-    NSArray *args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self launchSim];
 }
 
 - (void)testKillSim {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self killSim];
 }
 
-// Causes deadlock when run with other tests.
-//
-//- (void)testStartTest {
-//    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-//    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-//
-//    //Should launch sim
-//    args = @[kProgramName, @"start_test",
-//             @"-d", defaultSimUDID,
-//             @"-k", @"NO"];
-//    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-//
-//    args = @[kProgramName, @"start_test",
-//             @"-d", defaultSimUDID,
-//             @"-k", @"NO"];
-//    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-//}
-
-- (void)testUninstall {
+- (void)testStartTest {
+    [self installOrThrow:runner(self.platform) bundleID:kDeviceAgentBundleID shouldUpdate:NO];
     NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
     XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
 
-    args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", testAppID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
+    //Should launch sim
+    XCTAssertEqual([self startTest], iOSReturnStatusCodeEverythingOkay);
 
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    //Should work even though sim is already launched
+    XCTAssertEqual([self startTest], iOSReturnStatusCodeEverythingOkay);
+}
 
-    args = @[kProgramName, @"is_installed", @"-b", testAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a",
-                 [self.resources TestAppPath:SIM]];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-
-    args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", testAppID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+- (void)testUninstall {
+    [self sharedUninstallTest];
 }
 
 - (void)testInstall {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"is_installed", @"-b", taskyAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", tasky(SIM)];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self sharedInstallTest];
 }
 
 - (void)testAppIsInstalled {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"is_installed", @"-b", @"com.apple.Preferences", @"-d",
-             defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"is_installed", @"-b", testAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", testAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-
-    args = @[kProgramName, @"is_installed", @"-b", testAppID, @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeFalse);
-
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", testApp(SIM)];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"is_installed", @"-b", testAppID, @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self sharedAppIsInstalledTest];
 }
 
-
 - (void)testAppUpdate {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    //Ensure app is not installed
-    args = @[kProgramName, @"is_installed", @"-b", testAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", testAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-
-    //Set app's info.plist CFBundleVersion to 1.0
-    NSString *tmpDir = [self.resources uniqueTmpDirectory];
-    NSString *source = testApp(SIM);
-    NSString *target = [tmpDir stringByAppendingPathComponent:[source lastPathComponent]];
-    [self.resources copyDirectoryWithSource:source target:target];
-
-    XCTAssertTrue([self.resources updatePlistForBundle:target
-                                                   key:@"CFBundleVersion"
-                                                 value:@"1.0"]);
-
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", target];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    //Ensure that the installed app has CFBundleVersion 1.0
-    NSString *installedVersion = [self bundleVersionForInstalledTestApp];
-    XCTAssertEqualObjects(installedVersion, @"1.0",
-                          @"Installed app's Info.plist doesn't match");
-
-    //Now update the local plist to have CFBundleVersion 2.0
-    XCTAssertTrue([self.resources updatePlistForBundle:target
-                                                   key:@"CFBundleVersion"
-                                                 value:@"2.0"]);
-
-    //Install the app and ensure that the new version has been installed
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", target];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    installedVersion = [self bundleVersionForInstalledTestApp];
-    XCTAssertEqualObjects(installedVersion, @"2.0",
-                          @"Installed app's Info.plist doesn't match");
-
-
-    //Now change it back to 1.0 and try to install while setting `-u` to false.
-    //We should see that the installed version remains at 2.0
-    XCTAssertTrue([self.resources updatePlistForBundle:target
-                                                   key:@"CFBundleVersion"
-                                                 value:@"1.0"]);
-
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", target, @"-u", @"NO"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    installedVersion = [self bundleVersionForInstalledTestApp];
-    XCTAssertEqualObjects(installedVersion, @"2.0",
-                          @"App was updated even though -u was set to NO");
+    [self sharedAppUpdateTest];
 }
 
 - (void)testUploadFile {
-    NSArray *args = @[kProgramName, @"kill_simulator", @"-d", defaultSimUDID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"launch_simulator", @"-d", defaultSimUDID];
-    iOSReturnStatusCode launchSimResult;
-    
-    for (int i = 1; i <= 30; i++) {
-        launchSimResult = [CLI process:args];
-        if (launchSimResult == iOSReturnStatusCodeInternalError) {
-            [NSThread sleepForTimeInterval:1.0f];
-        } else {
-            break;
-        }
-    }
-    
-    XCTAssertEqual(launchSimResult, iOSReturnStatusCodeEverythingOkay);
-    
-    //Ensure app not installed
-    args = @[
-             kProgramName, @"is_installed",
-             @"-b", testAppID,
-             @"-d", defaultSimUDID
-             ];
-    
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[
-                 kProgramName, @"uninstall",
-                 @"-b", testAppID,
-                 @"-d", defaultSimUDID,
-                 ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[
-             kProgramName, @"install",
-             @"-d", defaultSimUDID,
-             @"-a", testApp(SIM),
-             @"-c", kCodeSignIdentityKARL
-             ];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    //Upload a unique file
-    NSString *file = uniqueFile();
-    args = @[
-             kProgramName, @"upload",
-             @"-b", testAppID,
-             @"-d", defaultSimUDID,
-             @"-f", file,
-             @"-o", @"NO"
-             ];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    //Now attempt to overwrite with -o false
-    args = @[
-             kProgramName, @"upload",
-             @"-b", testAppID,
-             @"-d", defaultSimUDID,
-             @"-f", file,
-             @"-o", @"NO"
-             ];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
-    
-    //Now attempt to overwrite with -o true
-    args = @[
-             kProgramName, @"upload",
-             @"-b", testAppID,
-             @"-d", defaultSimUDID,
-             @"-f", file,
-             @"-o", @"YES"
-             ];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self sharedUploadFileTest];
 }
 
 - (void)testOptionalDeviceIDArg {
-    if ([DeviceUtils availableDevices].count > 0) {
-        NSLog(@"Detected physical device - skipping optional device arg simulator tests");
+    if ([DeviceUtils availablePhysicalDevices].count > 0) {
+        NSLog(@"Physical device detected - skipping optional device arg tests for simulator");
         return;
     }
     
-    NSArray *args = @[kProgramName, @"kill_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"launch_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"is_installed", @"-b", testAppID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-b", testAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[kProgramName, @"install", @"-a", testApp(SIM)];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self sharedOptionalArgsTest];
 }
 
 - (void)testPositionalArgs {
-    NSArray *args = @[kProgramName, @"kill_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"launch_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    NSString *deviceID = [DeviceUtils defaultSimulatorID];
-    args = @[kProgramName, @"is_installed", deviceID, @"-b", testAppID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", deviceID, @"-b", testAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[kProgramName, @"install", testApp(SIM), deviceID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"is_installed", deviceID, @"-b", testAppID];
-    if ([CLI process:args]) {
-        args = @[kProgramName, @"uninstall", deviceID, @"-b", testAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[kProgramName, @"install", deviceID, testApp(SIM)];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"install", testApp(SIM), deviceID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"install", deviceID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeMissingArguments);
-    
-    args = @[kProgramName, @"install", deviceID, testApp(SIM), @"-a", @"/path/to/another/app"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
-    
-    args = @[kProgramName, @"install", deviceID, testApp(SIM), @"-d", @"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeInvalidArguments);
+    [self sharedPositionalArgsTest];
 }
 
 - (void)testLaunchAndKillApp {
-    NSArray *args = @[kProgramName, @"kill_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"launch_simulator"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"is_installed", @"-b", testAppID];
-    if ([CLI process:args] == iOSReturnStatusCodeFalse) {
-        args = @[kProgramName, @"install", testApp(SIM), [DeviceUtils defaultSimulatorID]];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    args = @[kProgramName, @"launch_app", [DeviceUtils defaultSimulatorID], @"-b", testAppID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"kill_app", [DeviceUtils defaultSimulatorID], @"-b", testAppID];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    [self sharedLaunchAndKillAppTest];
 }
 
 @end

--- a/Tests/Resources.h
+++ b/Tests/Resources.h
@@ -28,7 +28,8 @@ NS_INLINE BOOL version_lte(NSString* a, NSString* b) {
 
 #pragma mark - Constants
 
-static NSString *const kProgramName = @"iOSDeviceManagement";
+static NSString *const kProgramName = @"iOSDeviceManager";
+static NSString *const kDeviceAgentBundleID = @"com.apple.test.DeviceAgent-Runner";
 
 static NSString *const kCodeSignIdentityKARL =
 @"iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
@@ -118,7 +119,15 @@ static NSString *const SIM = @"SIM";
 - (TestDevice *)defaultDevice;
 - (NSString *)defaultDeviceUDID;
 
+
+/*
+    Returns absolute path to a test app
+*/
 - (NSString *)TestAppPath:(NSString *)platform;
+/*
+    Relative path to a test app with at least one ".." in the path
+*/
+- (NSString *)TestAppRelativePath:(NSString *)platform;
 - (NSString *)TestAppIdentifier;
 - (NSString *)TaskyPath:(NSString *)platform;
 - (NSString *)TaskyIpaPath;

--- a/Tests/Resources.m
+++ b/Tests/Resources.m
@@ -520,11 +520,25 @@ static NSString *const kTmpDirectory = @".iOSDeviceManager/Tests/";
 
 - (NSString *)TestAppPath:(NSString *)platform {
     if ([ARM isEqualToString:platform]) {
+        return [[self.resourcesDirectory
+                 stringByAppendingPathComponent:@"arm/TestApp.app"]
+                stringByStandardizingPath];
+    } else if ([SIM isEqualToString:platform]) {
+        return [[self.resourcesDirectory
+                 stringByAppendingPathComponent:@"sim/TestApp.app"]
+                stringByStandardizingPath];
+    } else {
+        return nil;
+    }
+}
+
+- (NSString *)TestAppRelativePath:(NSString *)platform {
+    if ([ARM isEqualToString:platform]) {
         return [self.resourcesDirectory
-                stringByAppendingPathComponent:@"arm/TestApp.app"];
+                stringByAppendingPathComponent:@"arm/../arm/TestApp.app"];
     } else if ([SIM isEqualToString:platform]) {
         return [self.resourcesDirectory
-                stringByAppendingPathComponent:@"sim/TestApp.app"];
+                stringByAppendingPathComponent:@"sim/../sim/TestApp.app"];
     } else {
         return nil;
     }

--- a/Tests/TestCase.h
+++ b/Tests/TestCase.h
@@ -1,26 +1,5 @@
-#import "Resources.h"
 #import <XCTest/XCTest.h>
-#import "DeviceUtils.h"
-
-#define testAppID [[Resources shared] TestAppIdentifier]
-#define testApp( platform )  [[Resources shared] TestAppPath:platform]
-#define taskyAppID [[Resources shared] TaskyIdentifier]
-#define tasky( platform ) [[Resources shared] TaskyPath:platform]
-#define runner( platform ) [[Resources shared] DeviceAgentPath:platform]
-#define xctest( platform ) [[Resources shared] DeviceAgentXCTestPath:platform]
-#define uniqueFile() [[Resources shared] uniqueFileToUpload]
-#define defaultSimUDID [DeviceUtils defaultSimulatorID]
-#define defaultDeviceUDID [DeviceUtils defaultPhysicalDeviceIDEnsuringOnlyOneAttached:NO]
-
-NS_INLINE BOOL device_available() {
-    if ([[Resources shared] isCompatibleDeviceConnected]) {
-        return YES;
-    } else {
-        NSLog(@"No compatible device connected; skipping test");
-        return NO;
-    }
-}
-
+#import "TestUtils.h"
 
 @interface TestCase : XCTestCase
 

--- a/Tests/TestCase.m
+++ b/Tests/TestCase.m
@@ -5,10 +5,7 @@
 @synthesize resources = _resources;
 
 - (Resources *)resources {
-    if (_resources) { return _resources; }
-
-    _resources = [Resources shared];
-    return _resources;
+    return [Resources shared]; //it's a dispatch_once'd singleton
 }
 
 - (void)setUp {

--- a/Tests/TestUtils.h
+++ b/Tests/TestUtils.h
@@ -1,0 +1,26 @@
+#import "Resources.h"
+#import "DeviceUtils.h"
+
+#define testAppID [[Resources shared] TestAppIdentifier]
+#define testApp( platform )  [[Resources shared] TestAppPath:platform]
+#define taskyAppID [[Resources shared] TaskyIdentifier]
+#define tasky( platform ) [[Resources shared] TaskyPath:platform]
+#define runner( platform ) [[Resources shared] DeviceAgentPath:platform]
+#define xctest( platform ) [[Resources shared] DeviceAgentXCTestPath:platform]
+#define uniqueFile() [[Resources shared] uniqueFileToUpload]
+#define defaultSimUDID [DeviceUtils defaultSimulatorID]
+#define defaultDeviceUDID [DeviceUtils defaultPhysicalDeviceIDEnsuringOnlyOneAttached:NO]
+
+NS_INLINE BOOL device_available() {
+    if ([[Resources shared] isCompatibleDeviceConnected]) {
+        return YES;
+    } else {
+        NSLog(@"No compatible device connected; skipping test");
+        return NO;
+    }
+}
+
+
+@interface TestUtils : NSObject
+
+@end

--- a/Tests/TestUtils.m
+++ b/Tests/TestUtils.m
@@ -1,0 +1,6 @@
+
+#import "TestUtils.h"
+
+@implementation TestUtils
+
+@end

--- a/Tests/Unit/CLITests.m
+++ b/Tests/Unit/CLITests.m
@@ -122,7 +122,7 @@
 }
 
 - (void)testOptionalArg {
-    if ([[DeviceUtils availableDevices] count] < 2) {
+    if ([[DeviceUtils availablePhysicalDevices] count] < 2) {
         NSArray *args = @[kProgramName, @"install", @"-a", @"fake/path/to/.app"];
         XCTAssertEqual([CLI process:args], iOSReturnStatusCodeGenericFailure);
         

--- a/iOSDeviceManager.xcodeproj/project.pbxproj
+++ b/iOSDeviceManager.xcodeproj/project.pbxproj
@@ -199,6 +199,8 @@
 		B29B2DA41E2E93C800C4C7D1 /* DeviceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B29B2DA31E2E93C800C4C7D1 /* DeviceUtils.m */; };
 		B29B2DA51E2E93C800C4C7D1 /* DeviceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B29B2DA31E2E93C800C4C7D1 /* DeviceUtils.m */; };
 		B29B2DA61E2E93C800C4C7D1 /* DeviceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B29B2DA31E2E93C800C4C7D1 /* DeviceUtils.m */; };
+		B2C020371E775BC700FA442C /* DeviceCLIIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C020361E775BC700FA442C /* DeviceCLIIntegrationTests.m */; };
+		B2C0203A1E776B6D00FA442C /* TestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C020391E776B6D00FA442C /* TestUtils.m */; };
 		B2E68E181E38170E001D5D89 /* ResignCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E68E171E38170E001D5D89 /* ResignCommand.m */; };
 		B2E68E191E38170E001D5D89 /* ResignCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E68E171E38170E001D5D89 /* ResignCommand.m */; };
 		B2E68E1A1E38170E001D5D89 /* ResignCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E68E171E38170E001D5D89 /* ResignCommand.m */; };
@@ -470,6 +472,10 @@
 		B29B2DA31E2E93C800C4C7D1 /* DeviceUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DeviceUtils.m; path = iOSDeviceManager/Utilities/DeviceUtils.m; sourceTree = SOURCE_ROOT; };
 		B2BD7BAD1E451214009242C7 /* CodesignResources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CodesignResources.h; sourceTree = "<group>"; };
 		B2BD7BAE1E451340009242C7 /* CodesignResources.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CodesignResources.m; sourceTree = "<group>"; };
+		B2C020351E775B8C00FA442C /* DeviceCLIIntegrationTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeviceCLIIntegrationTests.h; sourceTree = "<group>"; };
+		B2C020361E775BC700FA442C /* DeviceCLIIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceCLIIntegrationTests.m; sourceTree = "<group>"; };
+		B2C020381E776B5F00FA442C /* TestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtils.h; sourceTree = "<group>"; };
+		B2C020391E776B6D00FA442C /* TestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestUtils.m; sourceTree = "<group>"; };
 		B2E68E161E3816DF001D5D89 /* ResignCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ResignCommand.h; path = iOSDeviceManager/Commands/ResignCommand.h; sourceTree = SOURCE_ROOT; };
 		B2E68E171E38170E001D5D89 /* ResignCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ResignCommand.m; path = iOSDeviceManager/Commands/ResignCommand.m; sourceTree = SOURCE_ROOT; };
 		B2E68E1B1E381731001D5D89 /* ResignAllCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ResignAllCommand.h; path = iOSDeviceManager/Commands/ResignAllCommand.h; sourceTree = SOURCE_ROOT; };
@@ -823,6 +829,8 @@
 		89EF4ACA1CFA614F006DCDC5 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				B2C020381E776B5F00FA442C /* TestUtils.h */,
+				B2C020391E776B6D00FA442C /* TestUtils.m */,
 				F5E8D8231D67B63700A41EFD /* TestCase.h */,
 				F5E8D8211D67B60A00A41EFD /* TestCase.m */,
 				F53764961D67A1FB009457C8 /* Resources.h */,
@@ -894,6 +902,8 @@
 			isa = PBXGroup;
 			children = (
 				F578F4671D70A3C4001FC3BE /* ResignTest.m */,
+				B2C020351E775B8C00FA442C /* DeviceCLIIntegrationTests.h */,
+				B2C020361E775BC700FA442C /* DeviceCLIIntegrationTests.m */,
 				F5D583DD1D69FE62007B0D11 /* PhysicalCLIDeviceIntegrationTests.m */,
 				F5D583DE1D69FE62007B0D11 /* SimulatorCLIIntegrationTests.m */,
 				63424B5EAA3E57132288C79A /* MobileProfileTest.m */,
@@ -1226,6 +1236,7 @@
 				898D7D401DA47513001578FE /* GCDAsyncSocket.m in Sources */,
 				89A1CF0E1E36F94B00D9FEC5 /* ExceptionUtils.m in Sources */,
 				89A1CF071E36CCCA00D9FEC5 /* FileUtils.m in Sources */,
+				B2C020371E775BC700FA442C /* DeviceCLIIntegrationTests.m in Sources */,
 				B2E68E1F1E381745001D5D89 /* ResignAllCommand.m in Sources */,
 				A18622721DE4F47700A05031 /* MachClock.m in Sources */,
 				B296D7021E31474500D365F3 /* Codesigner.m in Sources */,
@@ -1237,6 +1248,7 @@
 				F5D584021D6A0387007B0D11 /* InstallAppCommand.m in Sources */,
 				B296D7061E3147AE00D365F3 /* Certificate.m in Sources */,
 				89A1CF081E36CCFE00D9FEC5 /* JSONUtils.m in Sources */,
+				B2C0203A1E776B6D00FA442C /* TestUtils.m in Sources */,
 				F5D583FB1D6A0374007B0D11 /* Simulator.m in Sources */,
 				B296D7051E31475600D365F3 /* MobileProfile.m in Sources */,
 				B2E68E1A1E38170E001D5D89 /* ResignCommand.m in Sources */,

--- a/iOSDeviceManager/Utilities/DeviceUtils.h
+++ b/iOSDeviceManager/Utilities/DeviceUtils.h
@@ -9,7 +9,7 @@
 + (NSString *)defaultSimulatorID;
 + (NSString *)defaultPhysicalDeviceIDEnsuringOnlyOneAttached:(BOOL)shouldThrow;
 + (NSString *)defaultDeviceID;
-+ (NSArray<FBDevice *> *)availableDevices;
++ (NSArray<FBDevice *> *)availablePhysicalDevices;
 + (NSArray<FBSimulator *> *)availableSimulators;
 + (FBSimulator *)defaultSimulator:(NSArray<FBSimulator *>*)simulators;
 @end

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -28,7 +28,7 @@ const double EPSILON = 0.001;
     return did.length == 40 && [did isBase64];
 }
 
-+ (NSArray<FBDevice *> *)availableDevices {
++ (NSArray<FBDevice *> *)availablePhysicalDevices {
     return [[FBDeviceSet defaultSetWithLogger:nil error:nil] allDevices];
 }
 
@@ -103,7 +103,7 @@ const double EPSILON = 0.001;
 }
 
 + (NSString *)defaultPhysicalDeviceIDEnsuringOnlyOneAttached:(BOOL)shouldThrow {
-    NSArray<FBDevice *> *devices = [DeviceUtils availableDevices];
+    NSArray<FBDevice *> *devices = [DeviceUtils availablePhysicalDevices];
     
     if ([devices count] == 1) {
         return [devices firstObject].udid;


### PR DESCRIPTION
**Motivation**

Currently there's redundant code for integration testing physical device vs simulator. The purpose of this PR is to share more code between the physical device integration tests and simulator integration tests since in principle they often only differ in the device id that's specified or the app path used (i.e. .app vs .ipa). 
This is a simplification of PR #119 with the testing changes in a separate branch.