### PR TITLE
Fix relative app paths with leading ../ or ./

### DIFF
--- a/Tests/Integration/SimulatorCLIIntegrationTests.m
+++ b/Tests/Integration/SimulatorCLIIntegrationTests.m
@@ -113,6 +113,29 @@
 
     args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", tasky(SIM)];
     XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    args = @[kProgramName, @"is_installed", @"-b", taskyAppID, @"-d", defaultSimUDID];
+    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
+        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
+        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    }
+
+    // Test Relative App Path
+    NSString *relativeAppPath = [[Resources shared] TestAppRelativePath:SIM];
+    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", relativeAppPath];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+
+    args = @[kProgramName, @"is_installed", @"-b", taskyAppID, @"-d", defaultSimUDID];
+    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
+        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
+        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
+    }
+
+    // Test Relative App Path with leading ../
+    NSFileManager *manager = [NSFileManager defaultManager];
+    [manager changeCurrentDirectoryPath:relativeAppPath];
+    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", @"../TestApp.app"];
+    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
 }
 
 - (void)testAppIsInstalled {

--- a/Tests/Resources.h
+++ b/Tests/Resources.h
@@ -131,6 +131,10 @@ typedef NS_ENUM(NSUInteger, TestSimulatorState) {
 - (NSString *)defaultDeviceUDID;
 
 - (NSString *)TestAppPath:(NSString *)platform;
+/*
+    Relative path to a test app with at least one ".." in the path
+*/
+- (NSString *)TestAppRelativePath:(NSString *)platform;
 - (NSString *)TestAppIdentifier;
 - (NSString *)TaskyPath:(NSString *)platform;
 - (NSString *)TaskyIpaPath;

--- a/Tests/Resources.m
+++ b/Tests/Resources.m
@@ -570,6 +570,18 @@ static NSString *const kTmpDirectory = @".iOSDeviceManager/Tests/";
     }
 }
 
+- (NSString *)TestAppRelativePath:(NSString *)platform {
+    if ([ARM isEqualToString:platform]) {
+        return [self.resourcesDirectory
+                stringByAppendingPathComponent:@"arm/../arm/TestApp.app"];
+    } else if ([SIM isEqualToString:platform]) {
+        return [self.resourcesDirectory
+                stringByAppendingPathComponent:@"sim/../sim/TestApp.app"];
+    } else {
+        return nil;
+    }
+}
+
 /*
     Copy the testfile to a unique filename in the tmp dir and return that
  */

--- a/iOSDeviceManager/Application/Application.m
+++ b/iOSDeviceManager/Application/Application.m
@@ -3,6 +3,7 @@
 #import "ShellRunner.h"
 #import "ShellResult.h"
 #import "ConsoleWriter.h"
+#import "FileUtils.h"
 #import <FBSimulatorControl/FBSimulatorControl.h>
 #import <FBDeviceControl/FBDeviceControl.h>
 #import <XCTestBootstrap/XCTestBootstrap.h>
@@ -10,7 +11,7 @@
 @implementation Application
 
 + (Application *)withBundlePath:(NSString *)pathToBundle {
-    NSString *path = [pathToBundle stringByStandardizingPath];
+    NSString *path = [FileUtils standardizedPath:pathToBundle];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     
     if (![fileManager fileExistsAtPath:path]) {

--- a/iOSDeviceManager/Utilities/FileUtils.h
+++ b/iOSDeviceManager/Utilities/FileUtils.h
@@ -7,6 +7,6 @@ typedef void(^filePathHandler)(NSString *filepath);
 //Calls handler() on every file in dir, recursively. Depth first.
 //Unlike clojure, `dir` must point to a real file or this method will throw up.  
 + (void)fileSeq:(NSString *)dir handler:(filePathHandler)handler;
-
 + (BOOL)isDylibOrFramework:(NSString *)objectPath;
++ (NSString *)standardizedPath:(NSString *)path;
 @end

--- a/iOSDeviceManager/Utilities/FileUtils.m
+++ b/iOSDeviceManager/Utilities/FileUtils.m
@@ -32,4 +32,21 @@
     return [objectPath hasSuffix:@".framework"] ||
     [objectPath hasSuffix:@".dylib"];
 }
+
++ (NSString *)standardizedPath:(NSString *)path {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSMutableString *standardPath = [path mutableCopy];
+    if ([standardPath hasPrefix:@".."]) {
+        NSString *currentDirectory = [fileManager currentDirectoryPath];
+        standardPath = [[currentDirectory stringByAppendingPathComponent:standardPath] mutableCopy];
+    }
+    if ([standardPath hasPrefix:@"."]) {
+        NSString *currentDirectory = [fileManager currentDirectoryPath];
+        [standardPath replaceOccurrencesOfString:@"."
+                                      withString:currentDirectory
+                                         options:NSCaseInsensitiveSearch
+                                           range:NSMakeRange(0, 1)];
+    }
+    return [standardPath stringByStandardizingPath];
+}
 @end


### PR DESCRIPTION
**REBASED** Fri Mar 31 9:46 CET

**Motivation**
`stringByAppendingPathComponent` doesn't handle leading .. or . in a relative path so I created a method in attempts to handle that and a corresponding test. 
Jira issue #1018

@jmoody I tested the .app in DeviceAgent.iOS however ran into issues with testing the .ipa with either the full or relative paths due to
```
2017-03-28 15:30:51.862 DEBUG FBControlCoreLogger:130 | Failed to load the Xcode frameworks for FBDeviceControl with error Error Domain=com.facebook.FBControlCore Code=0 "Missing Framework libswiftAppKit.dylib                                                                                                                                         
Referenced from: /Applications/Xcode.app/Contents/Frameworks/IDEFoundation.framework could not be loaded from any fallback directories" UserInfo={NSLocalizedDescription=Missing Framework libswiftAppKit.dylib                                                                                                                                         
Referenced from: /Applications/Xcode.app/Contents/Frameworks/IDEFoundation.framework could not be loaded from any fallback directories}          
```
I guess issue: https://github.com/facebook/FBSimulatorControl/issues/375 but maybe PR #126 addresses that?

**Update**: After merging PR #126 I no longer experience those issues installing the ipa