### PR TITLE
Adds support for relative path without a preceding . ../ or ~

### DIFF
--- a/Tests/Integration/SimulatorCLIIntegrationTests.m
+++ b/Tests/Integration/SimulatorCLIIntegrationTests.m
@@ -119,35 +119,6 @@
         args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
         XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
     }
-
-    // Test Relative App Path
-    NSString *relativeAppPath = [[Resources shared] TestAppRelativePath:SIM];
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", relativeAppPath];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-
-    args = @[kProgramName, @"is_installed", @"-b", taskyAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-
-    // Test Relative App Path with leading ../
-    NSFileManager *manager = [NSFileManager defaultManager];
-    [manager changeCurrentDirectoryPath:relativeAppPath];
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", @"../TestApp.app"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    
-    args = @[kProgramName, @"is_installed", @"-b", taskyAppID, @"-d", defaultSimUDID];
-    if ([CLI process:args] == iOSReturnStatusCodeEverythingOkay) {
-        args = @[kProgramName, @"uninstall", @"-d", defaultSimUDID, @"-b", taskyAppID];
-        XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
-    }
-    
-    // Test Relative App Path without leading ../ or ./
-    NSString *parentRelativeAppPath = [relativeAppPath stringByAppendingPathComponent:@"../"];
-    [manager changeCurrentDirectoryPath:parentRelativeAppPath];
-    args = @[kProgramName, @"install", @"-d", defaultSimUDID, @"-a", @"TestApp.app"];
-    XCTAssertEqual([CLI process:args], iOSReturnStatusCodeEverythingOkay);
 }
 
 - (void)testAppIsInstalled {

--- a/Tests/Unit/Utilities/FileUtilsTest.m
+++ b/Tests/Unit/Utilities/FileUtilsTest.m
@@ -9,4 +9,50 @@
 
 @implementation FileUtilsTest
 
+- (void)testExpandPath {
+    NSString *path, *expected, *actual;
+    NSString *currentDirectory = [[NSFileManager defaultManager] currentDirectoryPath];
+
+    path = @"~/path/relative/to/home";
+    expected = [NSHomeDirectory() stringByAppendingPathComponent:@"path/relative/to/home"];
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"/path/with/../embedded/relative/component";
+    expected = @"/path/embedded/relative/component";
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"/path/with/./embedded/relative/component";
+    expected = @"/path/with/embedded/relative/component";
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"/path/with///unnecessary/path/separator";
+    expected = @"/path/with/unnecessary/path/separator";
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"//path/with/unnecessary/path/separator";
+    expected = @"/path/with/unnecessary/path/separator";
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"./path/with/leading/dot";
+    expected = [currentDirectory stringByAppendingPathComponent:@"path/with/leading/dot"];
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"path/relative/to/current/directory";
+    expected = [currentDirectory stringByAppendingPathComponent:@"path/relative/to/current/directory"];
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+
+    path = @"../path/with/leading/relative/component";
+    NSString *upOneDirectory = [currentDirectory stringByDeletingLastPathComponent];
+    expected = [upOneDirectory stringByAppendingPathComponent:@"path/with/leading/relative/component"];
+    actual = [FileUtils expandPath:path];
+    expect(actual).to.equal(expected);
+}
+
 @end

--- a/iOSDeviceManager/Application/Application.m
+++ b/iOSDeviceManager/Application/Application.m
@@ -11,7 +11,7 @@
 @implementation Application
 
 + (Application *)withBundlePath:(NSString *)pathToBundle {
-    NSString *path = [FileUtils standardizedPath:pathToBundle];
+    NSString *path = [FileUtils expandPath:pathToBundle];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     
     if (![fileManager fileExistsAtPath:path]) {

--- a/iOSDeviceManager/Utilities/FileUtils.h
+++ b/iOSDeviceManager/Utilities/FileUtils.h
@@ -8,5 +8,5 @@ typedef void(^filePathHandler)(NSString *filepath);
 //Unlike clojure, `dir` must point to a real file or this method will throw up.  
 + (void)fileSeq:(NSString *)dir handler:(filePathHandler)handler;
 + (BOOL)isDylibOrFramework:(NSString *)objectPath;
-+ (NSString *)standardizedPath:(NSString *)path;
++ (NSString *)expandPath:(NSString *)path;
 @end

--- a/iOSDeviceManager/Utilities/FileUtils.m
+++ b/iOSDeviceManager/Utilities/FileUtils.m
@@ -33,7 +33,7 @@
     [objectPath hasSuffix:@".dylib"];
 }
 
-+ (NSString *)standardizedPath:(NSString *)path {
++ (NSString *)expandPath:(NSString *)path {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSMutableString *standardPath = [path mutableCopy];
     if ([standardPath hasPrefix:@".."]) {


### PR DESCRIPTION
**Motivation**
Adds support for relative path without a preceding .. . or ~

 i.e. `idm install TestApp.app`