### PR TITLE
Uninstall app before install to avoid "application-identifier entitlements mismatch" error

### DIFF
--- a/iOSDeviceManager/Devices/PhysicalDevice.m
+++ b/iOSDeviceManager/Devices/PhysicalDevice.m
@@ -109,6 +109,11 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
         if (ret != iOSReturnStatusCodeEverythingOkay) {
             return ret;
         }
+        if (needsToInstall) {
+            // Uninstall app to avoid application-identifier entitlement mismatch
+            // during installation update
+            [self uninstallApp:app.bundleID];
+        }
     }
 
     //Only codesign/install if we actually need to.


### PR DESCRIPTION
**Motivation**

Uninstalls app during app installation if an existing app is detected and an update is required. This solves the problem of reinstalling an app if it was signed with different code signing assets. The reason being that the application-identifier entitlement may mismatch causing FBSimControl to throw an exception with the message:
```
This application's application-identifier entitlement does not match that of the installed application. 
These values must match for an upgrade to be allowed.
```

I'm not entirely sure why we currently change the app-id entitlement during resigning but changing that is another solution to this problem. 