### PR TITLE
Sync with FBSimulatorControl week 17, 2017 part 1 of 2: source code changes

### DIFF
--- a/Tests/Unit/Devices/DeviceTest.m
+++ b/Tests/Unit/Devices/DeviceTest.m
@@ -16,6 +16,21 @@
     [super tearDown];
 }
 
+- (void)testStartTestArguments {
+    NSArray *array = [Device startTestArguments];
+    expect(array.count).to.equal(4);
+    expect(array).to.contain(@"-NSTreatUnknownArgumentsAsOpen");
+    expect(array).to.contain(@"NO");
+    expect(array).to.contain(@"-ApplePersistenceIgnoreState");
+    expect(array).to.contain(@"YES");
+}
+
+- (void)testStartTestEnvironment {
+    NSDictionary *dictionary = [Device startTestEnvironment];
+    expect(dictionary.count).to.equal(1);
+    expect(dictionary[@"XCTestConfigurationFilePath"]).to.equal(@"thanksforusingcalabash");
+}
+
 @end
 
 SpecBegin(DeviceTest)

--- a/iOSDeviceManager/Devices/Device.h
+++ b/iOSDeviceManager/Devices/Device.h
@@ -58,6 +58,8 @@
 @property BOOL testingComplete;
 
 + (instancetype)withID:(NSString *)uuid;
++ (NSArray<NSString *> *)startTestArguments;
++ (NSDictionary<NSString *, NSString *> *)startTestEnvironment;
 
 - (FBiOSDeviceOperator *)fbDeviceOperator;
 - (iOSReturnStatusCode)launch;

--- a/iOSDeviceManager/Devices/PhysicalDevice.m
+++ b/iOSDeviceManager/Devices/PhysicalDevice.m
@@ -385,8 +385,8 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
             sessionID, [self uuid], runnerID);
     NSError *error = nil;
 
-    NSArray *attributes = [FBTestRunnerConfigurationBuilder defaultBuildAttributes];
-    NSDictionary *environment = [FBTestRunnerConfigurationBuilder defaultBuildEnvironment];
+    NSArray *attributes = [Device startTestArguments];
+    NSDictionary *environment = [Device startTestEnvironment];
 
     BOOL staged = [self stageXctestConfigurationToTmpForBundleIdentifier:runnerID
                                                                    error:&error];

--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -401,11 +401,13 @@ static const FBSimulatorControl *_control;
 
     Simulator *replog = [Simulator new];
     [XCTestBootstrapFrameworkLoader loadPrivateFrameworksOrAbort];
+    NSArray *attributes = [Device startTestArguments];
+    NSDictionary *environment = [Device startTestEnvironment];
     FBTestManager *testManager = [FBXCTestRunStrategy startTestManagerForIOSTarget:self.fbSimulator
                                                                     runnerBundleID:runnerID
                                                                          sessionID:sessionID
-                                                                    withAttributes:[FBTestRunnerConfigurationBuilder defaultBuildAttributes]
-                                                                       environment:[FBTestRunnerConfigurationBuilder defaultBuildEnvironment]
+                                                                    withAttributes:attributes
+                                                                       environment:environment
                                                                           reporter:replog
                                                                             logger:replog
                                                                              error:&error];


### PR DESCRIPTION
### Motivation

Progress on:

* Sync with FBSimulatorControl week 17 [3461](https://msmobilecenter.visualstudio.com/Test/_workitems/edit/3461)

I replaced the **FBTestRunnerConfiguration: expose default attrs and env**[52215f](https://github.com/calabash/FBSimulatorControl/pull/28/commits/52215f4366040fc19c63e3af1c2a828c4ba77b37) commit on calabash/FBSimulatorControl with methods on the iOSDeviceManager/Device class.  

1. Removing commits on our fork reduces the chances of conflicts.
2. The change to #buildEnvironment in our fork was not used which was confusing.  There appears to be bug in that method; our XCTestConfigurationFile change will be clobbered I think.
3. Other than the `defaultBuildArguments` and `defaultBuildEnvironment` we were not using `FBTestRunnerConfiguration` directly.

### Test

This PR contains source changes only. CI is allowed failed because the required Frameworks are not in this change set. 

* https://github.com/calabash/FBSimulatorControl/pull/29
