### PR TITLE
Fix file uploading when targeting physical devices

### DIFF
--- a/iOSDeviceManager/Commands/UploadFileCommand.m
+++ b/iOSDeviceManager/Commands/UploadFileCommand.m
@@ -20,7 +20,11 @@ static NSString *const OVERWRITE_FLAG = @"-o";
     if (!device) {
         return iOSReturnStatusCodeDeviceNotFound;
     }
-    
+
+    if (![device isInstalled:args[BUNDLE_ID_FLAG] withError:nil]) {
+        return iOSReturnStatusCodeFalse;
+    }
+
     return [device uploadFile:args[FILEPATH_FLAG] forApplication:args[BUNDLE_ID_FLAG] overwrite:overwrite];
 }
 


### PR DESCRIPTION
Adds check if app is installed before attempting to upload file

**Motivation**
`upload` fails on physical device with: `Unable to download app data for bundle_id to dir: (null)`. After debugging the issue, I noticed `[self.fbDevice.dvtDevice applications]` was nil which was fixed by waiting with a runloop spinner: 
```
[spinner spinUntilTrue:^BOOL () {
        return [self.fbDevice.dvtDevice applications] != nil;
}];
```
but checking if the app is installed waits for dvtDevice to load applications plus provides a necessary check before attempting to upload a file to an installed app.  VSTS Issue: 7551
