### PR TITLE
Fetching applications before downloading app data prevents failures

### DIFF
--- a/iOSDeviceManager/Devices/Device.h
+++ b/iOSDeviceManager/Devices/Device.h
@@ -14,6 +14,7 @@
 
 - (NSDictionary *)installedApplicationWithBundleIdentifier:(NSString *)bundleID;
 - (BOOL)uninstallApplicationWithBundleID:(NSString *)bundleID error:(NSError **)error;
+- (void)fetchApplications;
 
 @end
 

--- a/iOSDeviceManager/Devices/PhysicalDevice.m
+++ b/iOSDeviceManager/Devices/PhysicalDevice.m
@@ -69,7 +69,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
 }
 
 - (FBiOSDeviceOperator *)fbDeviceOperator {
-    return (FBiOSDeviceOperator *)self.fbDevice.deviceOperator;
+    return [FBiOSDeviceOperator forDevice:self.fbDevice];
 }
 
 - (iOSReturnStatusCode)launch {
@@ -452,7 +452,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
 // */
 - (iOSReturnStatusCode)uploadFile:(NSString *)filepath forApplication:(NSString *)bundleID overwrite:(BOOL)overwrite {
 
-    FBiOSDeviceOperator *operator = ((FBiOSDeviceOperator *)self.fbDevice.deviceOperator);
+    FBiOSDeviceOperator *operator = [self fbDeviceOperator];
 
     NSError *e;
 
@@ -484,6 +484,7 @@ forInstalledApplicationWithBundleIdentifier:(NSString *)arg2
         return iOSReturnStatusCodeGenericFailure;
     }
 
+    [operator fetchApplications];
     if (![self.fbDevice.dvtDevice downloadApplicationDataToPath:xcappdataPath
                     forInstalledApplicationWithBundleIdentifier:bundleID
                                                           error:&e]) {


### PR DESCRIPTION
**Motivation**

`upload` file tests were failing on physical device because the apps needed to be fetched before attempting to download app data.

This PR requires changes to calabash/FBSimControl (which I don't seem to have access to push to?) frameworks. The change is just:

```
- (void)fetchApplications
  {
    if (!self.device.dvtDevice.applications) {
      [FBRunLoopSpinner spinUntilBlockFinished:^id{
        DVTFuture *future = self.device.dvtDevice.token.fetchApplications;
        [future waitUntilFinished];
        return nil;
       }];
     }
   }
```

which is already in FBSimControl master
