### PR TITLE
Fixed is-installed command simulator bug

### DIFF
--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -650,6 +650,12 @@ static const FBSimulatorControl *_control;
 - (iOSReturnStatusCode)isInstalled:(NSString *)bundleID {
 
     NSError *error = nil;
+    if (![self boot]) {
+        ConsoleWriteErr(@"Cannot check for installed application"
+                        "%@ on Simulator %@ because the device could not "
+                        "be booted", bundleID, self.fbSimulator);
+        return iOSReturnStatusCodeInternalError;
+    }
     BOOL installed = [self isInstalled:bundleID withError:&error];
 
     if (installed) {


### PR DESCRIPTION
[VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/Krukow-M1-Team/_workitems/edit/36957)

Fixed simulator bug for `is-installed` command which caused wrong output but throws no errors.

