### PR TITLE
-d,--device-id parameter now accepts also alias

### DIFF
--- a/iOSDeviceManager/Commands/AppInfoCommand.m
+++ b/iOSDeviceManager/Commands/AppInfoCommand.m
@@ -30,7 +30,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:NO
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/AppInfoCommand.m
+++ b/iOSDeviceManager/Commands/AppInfoCommand.m
@@ -30,7 +30,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:NO
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/ClearAppDataCommand.m
+++ b/iOSDeviceManager/Commands/ClearAppDataCommand.m
@@ -29,7 +29,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
                              defaultVal:nil],
             [CommandOption withPosition:1
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                required:NO
                              defaultVal:nil]
         ];

--- a/iOSDeviceManager/Commands/ClearAppDataCommand.m
+++ b/iOSDeviceManager/Commands/ClearAppDataCommand.m
@@ -29,7 +29,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
                              defaultVal:nil],
             [CommandOption withPosition:1
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                required:NO
                              defaultVal:nil]
         ];

--- a/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
+++ b/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
@@ -35,7 +35,7 @@ static NSString *const DOWNLOAD_PATH_OPTION_NAME = @"download-path";
                              defaultVal:nil],
             [CommandOption withPosition:2
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                required:NO
                              defaultVal:nil]
          ];

--- a/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
+++ b/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
@@ -35,7 +35,7 @@ static NSString *const DOWNLOAD_PATH_OPTION_NAME = @"download-path";
                              defaultVal:nil],
             [CommandOption withPosition:2
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                required:NO
                              defaultVal:nil]
          ];

--- a/iOSDeviceManager/Commands/EraseSimulatorCommand.m
+++ b/iOSDeviceManager/Commands/EraseSimulatorCommand.m
@@ -16,7 +16,7 @@
         options = @[
                     [CommandOption withPosition:0
                                      optionName:DEVICE_ID_OPTION_NAME
-                                           info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                           info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                        required:YES
                                      defaultVal:nil]
                     ];

--- a/iOSDeviceManager/Commands/EraseSimulatorCommand.m
+++ b/iOSDeviceManager/Commands/EraseSimulatorCommand.m
@@ -16,7 +16,7 @@
         options = @[
                     [CommandOption withPosition:0
                                      optionName:DEVICE_ID_OPTION_NAME
-                                           info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                           info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                        required:YES
                                      defaultVal:nil]
                     ];

--- a/iOSDeviceManager/Commands/InstallAppCommand.m
+++ b/iOSDeviceManager/Commands/InstallAppCommand.m
@@ -82,7 +82,7 @@ static NSString *const PROFILE_PATH_OPTION_NAME = @"profile-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:FORCE_UPDATE_APP_FLAG

--- a/iOSDeviceManager/Commands/InstallAppCommand.m
+++ b/iOSDeviceManager/Commands/InstallAppCommand.m
@@ -82,7 +82,7 @@ static NSString *const PROFILE_PATH_OPTION_NAME = @"profile-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:FORCE_UPDATE_APP_FLAG

--- a/iOSDeviceManager/Commands/IsInstalledCommand.m
+++ b/iOSDeviceManager/Commands/IsInstalledCommand.m
@@ -49,7 +49,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/IsInstalledCommand.m
+++ b/iOSDeviceManager/Commands/IsInstalledCommand.m
@@ -49,7 +49,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/KillAppCommand.m
+++ b/iOSDeviceManager/Commands/KillAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/KillAppCommand.m
+++ b/iOSDeviceManager/Commands/KillAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/LaunchAppCommand.m
+++ b/iOSDeviceManager/Commands/LaunchAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/LaunchAppCommand.m
+++ b/iOSDeviceManager/Commands/LaunchAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/SimulateLocationCommand.m
+++ b/iOSDeviceManager/Commands/SimulateLocationCommand.m
@@ -38,7 +38,7 @@ static NSString *const LOCATION_OPTION_NAME = @"latitude,longitude";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/SimulateLocationCommand.m
+++ b/iOSDeviceManager/Commands/SimulateLocationCommand.m
@@ -38,7 +38,7 @@ static NSString *const LOCATION_OPTION_NAME = @"latitude,longitude";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
+++ b/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
@@ -25,7 +25,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
+++ b/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
@@ -25,7 +25,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/UninstallAppCommand.m
+++ b/iOSDeviceManager/Commands/UninstallAppCommand.m
@@ -29,7 +29,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/UninstallAppCommand.m
+++ b/iOSDeviceManager/Commands/UninstallAppCommand.m
@@ -29,7 +29,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/UploadFileCommand.m
+++ b/iOSDeviceManager/Commands/UploadFileCommand.m
@@ -47,7 +47,7 @@ static NSString *const OVERWRITE_OPTION_NAME = @"overwrite";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:OVERWRITE_FLAG

--- a/iOSDeviceManager/Commands/UploadFileCommand.m
+++ b/iOSDeviceManager/Commands/UploadFileCommand.m
@@ -47,7 +47,7 @@ static NSString *const OVERWRITE_OPTION_NAME = @"overwrite";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:OVERWRITE_FLAG

--- a/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
@@ -63,7 +63,7 @@ static NSString *const FILEPATH_OPTION_NAME = @"file-path";
           [CommandOption withShortFlag:DEVICE_ID_FLAG
                               longFlag:@"--device-id"
                             optionName:DEVICE_ID_OPTION_NAME
-                                  info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                  info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                               required:YES
                             defaultVal:nil]
           ];

--- a/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
@@ -63,7 +63,7 @@ static NSString *const FILEPATH_OPTION_NAME = @"file-path";
           [CommandOption withShortFlag:DEVICE_ID_FLAG
                               longFlag:@"--device-id"
                             optionName:DEVICE_ID_OPTION_NAME
-                                  info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                  info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                               required:YES
                             defaultVal:nil]
           ];

--- a/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
@@ -59,7 +59,7 @@
               [CommandOption withShortFlag:DEVICE_ID_FLAG
                                   longFlag:@"--device-id"
                                 optionName:DEVICE_ID_OPTION_NAME
-                                      info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
+                                      info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
                                   required:YES
                                 defaultVal:nil]
           ];

--- a/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
@@ -59,7 +59,7 @@
               [CommandOption withShortFlag:DEVICE_ID_FLAG
                                   longFlag:@"--device-id"
                                 optionName:DEVICE_ID_OPTION_NAME
-                                      info:@"iOS Simulator GUID or 40-digit physical device ID"
+                                      info:@"iOS Simulator GUID or 40-digit physical device ID or alias"
                                   required:YES
                                 defaultVal:nil]
           ];

--- a/iOSDeviceManager/Devices/Device.m
+++ b/iOSDeviceManager/Devices/Device.m
@@ -31,6 +31,13 @@
 + (instancetype)withID:(NSString *)uuid {
     if ([DeviceUtils isSimulatorID:uuid]) { return [Simulator withID:uuid]; }
     if ([DeviceUtils isDeviceID:uuid]) { return [PhysicalDevice withID:uuid]; }
+
+    NSString *uuidFromName = [DeviceUtils findDeviceIDByName:uuid];
+    if (uuidFromName) {
+        if ([DeviceUtils isSimulatorID:uuidFromName]) { return [Simulator withID:uuidFromName]; }
+        if ([DeviceUtils isDeviceID:uuidFromName]) { return [PhysicalDevice withID:uuidFromName]; }
+    }
+    
     ConsoleWriteErr(@"Specified device ID does not match simulator or device");
     return nil;
 }

--- a/iOSDeviceManager/Utilities/DeviceUtils.h
+++ b/iOSDeviceManager/Utilities/DeviceUtils.h
@@ -9,6 +9,8 @@
 @interface DeviceUtils : NSObject
 + (BOOL)isDeviceID:(NSString *)uuid;
 + (BOOL)isSimulatorID:(NSString *)uuid;
++ (NSString*)findDeviceIDByName:(NSString *)name;
+
 
 + (NSString *)defaultSimulatorID;
 + (NSString *)defaultPhysicalDeviceIDEnsuringOnlyOneAttached:(BOOL)shouldThrow;

--- a/iOSDeviceManager/Utilities/DeviceUtils.h
+++ b/iOSDeviceManager/Utilities/DeviceUtils.h
@@ -9,9 +9,7 @@
 @interface DeviceUtils : NSObject
 + (BOOL)isDeviceID:(NSString *)uuid;
 + (BOOL)isSimulatorID:(NSString *)uuid;
-+ (NSString*)findDeviceIDByName:(NSString *)name;
-
-
++ (NSString *)findDeviceIDByName:(NSString *)name;
 + (NSString *)defaultSimulatorID;
 + (NSString *)defaultPhysicalDeviceIDEnsuringOnlyOneAttached:(BOOL)shouldThrow;
 + (NSString *)defaultDeviceID;

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -43,25 +43,41 @@ const double EPSILON = 0.001;
     return nil;
 }
 
+
 + (NSArray<FBDevice *> *)availableDevices {
-    return [[FBDeviceSet defaultSetWithLogger:nil error:nil] allDevices];
+    static dispatch_once_t onceToken = 0;
+    static NSArray<FBDevice *> *m_availableDevices;
+
+    dispatch_once(&onceToken, ^{
+        m_availableDevices = [[FBDeviceSet defaultSetWithLogger:nil error:nil] allDevices];
+    });
+    return m_availableDevices;
 }
 
+
 + (NSArray<FBSimulator *> *)availableSimulators {
-    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+    static dispatch_once_t onceToken = 0;
+    static NSArray<FBSimulator *> *m_availableSimulators;
+
+    dispatch_once(&onceToken, ^{
+
+        FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
                                                       configurationWithDeviceSetPath:nil
                                                       options:FBSimulatorManagementOptionsIgnoreSpuriousKillFail];
     
-    NSError *err;
-    FBSimulatorControl *simControl = [FBSimulatorControl withConfiguration:configuration error:&err];
-    if (err) {
-        ConsoleWriteErr(@"Error creating FBSimulatorControl: %@", err);
-        @throw [NSException exceptionWithName:@"GenericException"
+        NSError *err;
+        FBSimulatorControl *simControl = [FBSimulatorControl withConfiguration:configuration error:&err];
+        if (err) {
+            ConsoleWriteErr(@"Error creating FBSimulatorControl: %@", err);
+            @throw [NSException exceptionWithName:@"GenericException"
                                        reason:@"Failed detecting available simulators"
                                      userInfo:nil];
-    }
+        }
+
+        m_availableSimulators = [[simControl set] allSimulators];
+    });
     
-    return [[simControl set] allSimulators];
+    return m_availableSimulators;
 }
 
 + (FBSimulator *)defaultSimulator:(NSArray<FBSimulator *>*)simulators {

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -30,13 +30,11 @@ const double EPSILON = 0.001;
 
 + (NSString *)findDeviceIDByName:(NSString *)name {
 
-    NSArray<FBDevice *> *devices = [DeviceUtils availableDevices];
-    for (FBDevice *device in devices)
+    for (FBDevice *device in [DeviceUtils availableDevices])
         if ([device.name isEqualToString:name])
             return device.udid;
 
-    NSArray<FBSimulator *> *simulators = [DeviceUtils availableSimulators];
-    for (FBSimulator *simulator in simulators)
+    for (FBSimulator *simulator in [DeviceUtils availableSimulators])
         if ([simulator.name isEqualToString:name])
             return simulator.udid;
 
@@ -60,7 +58,6 @@ const double EPSILON = 0.001;
     static NSArray<FBSimulator *> *m_availableSimulators;
 
     dispatch_once(&onceToken, ^{
-
         FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
                                                       configurationWithDeviceSetPath:nil
                                                       options:FBSimulatorManagementOptionsIgnoreSpuriousKillFail];

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -28,20 +28,19 @@ const double EPSILON = 0.001;
     return did.length == 40 && [did isBase64];
 }
 
-+ (NSString*)findDeviceIDByName:(NSString *)name {
-    for (FBDevice* device in [DeviceUtils availableDevices])
-        if ([device.name isEqualToString:name]) {
-            ConsoleWrite(@"Physical device, UDID: %@", device.udid);
++ (NSString *)findDeviceIDByName:(NSString *)name {
+
+    NSArray<FBDevice *> *devices = [DeviceUtils availableDevices];
+    for (FBDevice *device in devices)
+        if ([device.name isEqualToString:name])
             return device.udid;
-        }
 
-    for (FBSimulator* simulator in [DeviceUtils availableSimulators])
-        if ([simulator.name isEqualToString:name]) {
-            ConsoleWrite(@"Simulator, UDID: %@", simulator.udid);
+    NSArray<FBSimulator *> *simulators = [DeviceUtils availableSimulators];
+    for (FBSimulator *simulator in simulators)
+        if ([simulator.name isEqualToString:name])
             return simulator.udid;
-        }
 
-    return NULL;
+    return nil;
 }
 
 + (NSArray<FBDevice *> *)availableDevices {

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -28,6 +28,22 @@ const double EPSILON = 0.001;
     return did.length == 40 && [did isBase64];
 }
 
++ (NSString*)findDeviceIDByName:(NSString *)name {
+    for (FBDevice* device in [DeviceUtils availableDevices])
+        if ([device.name isEqualToString:name]) {
+            ConsoleWrite(@"Physical device, UDID: %@", device.udid);
+            return device.udid;
+        }
+
+    for (FBSimulator* simulator in [DeviceUtils availableSimulators])
+        if ([simulator.name isEqualToString:name]) {
+            ConsoleWrite(@"Simulator, UDID: %@", simulator.udid);
+            return simulator.udid;
+        }
+
+    return NULL;
+}
+
 + (NSArray<FBDevice *> *)availableDevices {
     return [[FBDeviceSet defaultSetWithLogger:nil error:nil] allDevices];
 }

--- a/spec/device_app_life_cycle_spec.rb
+++ b/spec/device_app_life_cycle_spec.rb
@@ -57,12 +57,21 @@ describe "app life cycle (physical device)" do
                 DeviceAppLCHelper.uninstall(udid, app_dupe.bundle_identifier)
               end
 
-              it "installs app on device indicated by --device-id" do
+              it "installs app on device indicated with udid by --device-id" do
                 args = ["install", app.path, "--device-id", udid]
                 hash = IDM.shell(args)
                 expect(hash[:exit_status]).to be == IDM.exit_status(:success)
                 expect(
                   DeviceAppLCHelper.is_installed?(udid, app.bundle_identifier)
+                ).to be_truthy
+              end
+
+              it "installs app on device indicated with alias by --device-id" do
+                args = ["install", app.path, "--device-id", device.name]
+                hash = IDM.shell(args)
+                expect(hash[:exit_status]).to be == IDM.exit_status(:success)
+                expect(
+                  DeviceAppLCHelper.is_installed?(device.name, app.bundle_identifier)
                 ).to be_truthy
               end
 

--- a/spec/simulator_app_life_cycle_spec.rb
+++ b/spec/simulator_app_life_cycle_spec.rb
@@ -36,10 +36,20 @@ describe "app life cycle (simulator)" do
   context "installing apps on simulator" do
     let(:app_dupe) { RunLoop::App.new(IDM::Resources.instance.second_test_app(:x86)) }
 
-    it "installs app on simulator indicated by --device-id" do
+    it "installs app on simulator indicated with udid by --device-id" do
       SimAppLSHelper.prepare_for_install_test(core_sim)
 
       args = ["install", app.path, "--device-id", udid]
+      hash = IDM.shell(args)
+      expect(hash[:exit_status]).to be == IDM.exit_status(:success)
+
+      expect(core_sim.app_is_installed?).to be_truthy
+    end
+
+    it "installs app on simulator indicated with alias by --device-id" do
+      SimAppLSHelper.prepare_for_install_test(core_sim)
+
+      args = ["install", app.path, "--device-id", device.name]
       hash = IDM.shell(args)
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 


### PR DESCRIPTION
-d,--device-id <device-identifier> parameter now accepts these values:
	iOS Simulator GUID, or 40-digit physical device ID, or an alias