### PR TITLE
Stablize Simulator app life cycle events for Xcode 10 beta 6

### DIFF
--- a/iOSDeviceManager/Devices/Simulator.m
+++ b/iOSDeviceManager/Devices/Simulator.m
@@ -115,17 +115,9 @@ static const FBSimulatorControl *_control;
 }
 
 + (NSArray<NSString *> *)requiredSimulatorAppProcesses {
-    NSMutableArray *array = [
-                             @[@"com.apple.backboardd",
-                               @"com.apple.mobile.installd",
-                               @"com.apple.SpringBoard"
-                               ] mutableCopy];
-    if (FBXcodeConfiguration.isXcode9OrGreater) {
-        [array addObject:@"com.apple.CoreSimulator.bridge"];
-    } else if (FBXcodeConfiguration.isXcode8OrGreater) {
-        [array addObject:@"com.apple.SimulatorBridge"];
-    }
-    return [NSArray arrayWithArray:array];
+    return @[@"com.apple.backboardd",
+             @"com.apple.mobile.installd",
+             @"com.apple.SpringBoard"];
 }
 
 + (iOSReturnStatusCode)launchSimulator:(Simulator *)simulator {

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -44,8 +44,16 @@ const double EPSILON = 0.001;
             continue;
         }
 
+        NSString *versionStr = [NSString stringWithFormat:@"%@", version.number];
+
+        // 11 => 11.0
+        // 12 => 12.0
+        if (![versionStr containsString:@"."]) {
+            versionStr = [versionStr stringByAppendingString:@".0"];
+        }
+
         instrumentsName = [simulator.name stringByAppendingFormat:@" (%@)",
-                           version.number];
+                           versionStr];
 
         if ([instrumentsName isEqualToString:name]) {
             return simulator.udid;

--- a/spec/simulator_app_life_cycle_spec.rb
+++ b/spec/simulator_app_life_cycle_spec.rb
@@ -53,6 +53,7 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_truthy
@@ -63,6 +64,8 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", device.instruments_identifier]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
+
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_truthy
@@ -73,11 +76,14 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       args = ["install", app_dupe.path, "--device-id", udid]
       expect(app.bundle_version).not_to be == app_dupe.bundle_version
+
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_truthy
@@ -88,11 +94,13 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       args = ["install", app_dupe.path, "--device-id", udid]
       expect(app.marketing_version).not_to be == app_dupe.marketing_version
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_truthy
@@ -103,12 +111,14 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       args = ["install", app_dupe.path, "--device-id", udid]
       expect(app.bundle_version).not_to be == app_dupe.bundle_version
       expect(app.marketing_version).not_to be == app_dupe.marketing_version
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_truthy
@@ -119,9 +129,11 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       hash = IDM.shell(args << "--force")
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
       expect(core_sim.app_is_installed?).to be_truthy
       expect(hash[:out].include?("Installed")).to be_truthy
@@ -132,9 +144,11 @@ describe "app life cycle (simulator)" do
 
       args = ["install", app.path, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
       expect(hash[:out].include?("not reinstalling")).to be_truthy
     end
@@ -144,6 +158,7 @@ describe "app life cycle (simulator)" do
     it "returns an non-zero exit code if app is not installed" do
       args = ["uninstall", "com.example.NotInstalled", "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:failure)
     end
 
@@ -154,6 +169,7 @@ describe "app life cycle (simulator)" do
 
       args = ["uninstall", app.bundle_identifier, "--device-id", udid]
       hash = IDM.shell(args)
+      hash[:out].split("\n").each { |line| puts line }
       expect(hash[:exit_status]).to be == IDM.exit_status(:success)
 
       expect(core_sim.app_is_installed?).to be_falsey

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,9 +33,20 @@ RSpec.configure do |config|
 #config.filter_run :focus
 #config.run_all_when_everything_filtered = true
 
-# Many RSpec users commonly either run the entire suite or an individual
-# file, and it's useful to allow more verbose output when running an
-# individual spec file.
+  config.before(:suite) do
+    RunLoop.log_debug("Terminating stale CoreSimulator processes")
+    original = ENV["DEBUG"]
+    begin
+      ENV.delete("DEBUG")
+      RunLoop::CoreSimulator.terminate_core_simulator_processes
+    ensure
+      ENV["DEBUG"] = original
+    end
+  end
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured


### PR DESCRIPTION
### Motivation

Completes:

* Xcode 10: iOSDeviceManager all simulator rspec tests are failing on beta 6 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/45651)

### Tests

```
$ bundle exec rspec ./spec/simulator_app_life_cycle_spec.rb
Finished in 7 minutes 26 seconds (files took 0.30408 seconds to load)
14 examples, 0 failures, 5 pending
```

### TODO

- [x] drop 079e720 commit when https://github.com/calabash/run_loop/pull/694 is merged