### PR TITLE
 Update ruby test env and respond to Jenkins reinstall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "run_loop", github: "calabash/run_loop", branch: "develop"
+gem "json", "1.8.6"
 gem "rspec", "~> 3.0"
 gem "rspec_junit_formatter", "~> 0.2"
 gem "pry"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
   }
   options {
     disableConcurrentBuilds()
-    timestamps()
     buildDiscarder(logRotator(numToKeepStr: '10'))
     timeout(time: 75, unit: 'MINUTES')
   }


### PR DESCRIPTION
### Motivation

Jenkins has been reinstalled and the timestamper plug-in removed.

run_loop will soon be agnostic re: the json version