### PR TITLE
Added compatibility with new device ids

### DIFF
--- a/Tests/Resources.m
+++ b/Tests/Resources.m
@@ -363,7 +363,7 @@
 
 - (NSRegularExpression *)UDIDRegex {
     if (_UDIDRegex) { return _UDIDRegex; }
-    _UDIDRegex = [NSRegularExpression regularExpressionWithPattern:@"([a-f0-9]{40})"
+    _UDIDRegex = [NSRegularExpression regularExpressionWithPattern:@"([a-f0-9]{40}|([A-F0-9]{8}-[A-F0-9]{16}))"
                                                            options:0
                                                              error:NULL];
     return _UDIDRegex;

--- a/Tests/ResourcesTest.m
+++ b/Tests/ResourcesTest.m
@@ -45,8 +45,9 @@
     XCTAssertNil(actual);
 
     string = @"iPhone XS (12.0.1) [00008020-000C49542198002E]";
+    expected = @"00008020-000C49542198002E";
     actual = [[Instruments shared] extractUDID:string];
-    XCTAssertNil(actual);
+    XCTAssertEqualObjects(actual, expected);
 }
 
 - (void)testVersionRegex {

--- a/Tests/ResourcesTest.m
+++ b/Tests/ResourcesTest.m
@@ -43,6 +43,10 @@
     string = @"iPhone 5 (9.3) [D1B22B9C-F105-4DF0-8FA3-7AE41E212A9D] (Simulator)";
     actual = [[Instruments shared] extractUDID:string];
     XCTAssertNil(actual);
+
+    string = @"iPhone XS (12.0.1) [00008020-000C49542198002E]";
+    actual = [[Instruments shared] extractUDID:string];
+    XCTAssertNil(actual);
 }
 
 - (void)testVersionRegex {

--- a/iOSDeviceManager/Commands/AppInfoCommand.m
+++ b/iOSDeviceManager/Commands/AppInfoCommand.m
@@ -30,7 +30,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:NO
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/ClearAppDataCommand.m
+++ b/iOSDeviceManager/Commands/ClearAppDataCommand.m
@@ -29,7 +29,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
                              defaultVal:nil],
             [CommandOption withPosition:1
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                required:NO
                              defaultVal:nil]
         ];

--- a/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
+++ b/iOSDeviceManager/Commands/DownloadXCAppDataCommand.m
@@ -35,7 +35,7 @@ static NSString *const DOWNLOAD_PATH_OPTION_NAME = @"download-path";
                              defaultVal:nil],
             [CommandOption withPosition:2
                              optionName:DEVICE_ID_OPTION_NAME
-                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                required:NO
                              defaultVal:nil]
          ];

--- a/iOSDeviceManager/Commands/EraseSimulatorCommand.m
+++ b/iOSDeviceManager/Commands/EraseSimulatorCommand.m
@@ -16,7 +16,7 @@
         options = @[
                     [CommandOption withPosition:0
                                      optionName:DEVICE_ID_OPTION_NAME
-                                           info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                           info:@"iOS Simulator GUID, physical device ID, or an alias"
                                        required:YES
                                      defaultVal:nil]
                     ];

--- a/iOSDeviceManager/Commands/InstallAppCommand.m
+++ b/iOSDeviceManager/Commands/InstallAppCommand.m
@@ -82,7 +82,7 @@ static NSString *const PROFILE_PATH_OPTION_NAME = @"profile-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:FORCE_UPDATE_APP_FLAG

--- a/iOSDeviceManager/Commands/IsInstalledCommand.m
+++ b/iOSDeviceManager/Commands/IsInstalledCommand.m
@@ -49,7 +49,7 @@ static NSString *const APP_PATH_OPTION_NAME = @"app-path";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/KillAppCommand.m
+++ b/iOSDeviceManager/Commands/KillAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/LaunchAppCommand.m
+++ b/iOSDeviceManager/Commands/LaunchAppCommand.m
@@ -19,7 +19,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/SimulateLocationCommand.m
+++ b/iOSDeviceManager/Commands/SimulateLocationCommand.m
@@ -38,7 +38,7 @@ static NSString *const LOCATION_OPTION_NAME = @"latitude,longitude";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
+++ b/iOSDeviceManager/Commands/StopSimulatingLocationCommand.m
@@ -25,7 +25,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/UninstallAppCommand.m
+++ b/iOSDeviceManager/Commands/UninstallAppCommand.m
@@ -29,7 +29,7 @@
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
     });

--- a/iOSDeviceManager/Commands/UploadFileCommand.m
+++ b/iOSDeviceManager/Commands/UploadFileCommand.m
@@ -47,7 +47,7 @@ static NSString *const OVERWRITE_OPTION_NAME = @"overwrite";
         [options addObject:[CommandOption withShortFlag:DEVICE_ID_FLAG
                                                longFlag:@"--device-id"
                                              optionName:DEVICE_ID_OPTION_NAME
-                                                   info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                                   info:@"iOS Simulator GUID, physical device ID, or an alias"
                                                required:YES
                                              defaultVal:nil]];
         [options addObject:[CommandOption withShortFlag:OVERWRITE_FLAG

--- a/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCAppDataBundleCommand.m
@@ -63,7 +63,7 @@ static NSString *const FILEPATH_OPTION_NAME = @"file-path";
           [CommandOption withShortFlag:DEVICE_ID_FLAG
                               longFlag:@"--device-id"
                             optionName:DEVICE_ID_OPTION_NAME
-                                  info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                  info:@"iOS Simulator GUID, physical device ID, or an alias"
                               required:YES
                             defaultVal:nil]
           ];

--- a/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
+++ b/iOSDeviceManager/Commands/UploadXCTestConfigurationCommand.m
@@ -97,7 +97,7 @@
               [CommandOption withShortFlag:DEVICE_ID_FLAG
                                   longFlag:@"--device-id"
                                 optionName:DEVICE_ID_OPTION_NAME
-                                      info:@"iOS Simulator GUID, 40-digit physical device ID, or an alias"
+                                      info:@"iOS Simulator GUID, physical device ID, or an alias"
                                   required:YES
                                 defaultVal:nil]
           ];

--- a/iOSDeviceManager/Resigning/CodesignIdentity.m
+++ b/iOSDeviceManager/Resigning/CodesignIdentity.m
@@ -130,7 +130,7 @@
                                                           options:0
                                                             error:NULL];
     NSRegularExpression *identifierRegex;
-    identifierRegex = [NSRegularExpression regularExpressionWithPattern:@"([A-F0-9]{40})"
+    identifierRegex = [NSRegularExpression regularExpressionWithPattern:@"([a-f0-9]{40}|([A-F0-9]{8}-[A-F0-9]{16}))"
                                                                 options:0
                                                                   error:NULL];
     NSMutableArray<CodesignIdentity *> *identities = [@[] mutableCopy];

--- a/iOSDeviceManager/Resigning/CodesignIdentity.m
+++ b/iOSDeviceManager/Resigning/CodesignIdentity.m
@@ -130,7 +130,7 @@
                                                           options:0
                                                             error:NULL];
     NSRegularExpression *identifierRegex;
-    identifierRegex = [NSRegularExpression regularExpressionWithPattern:@"([a-f0-9]{40}|([A-F0-9]{8}-[A-F0-9]{16}))"
+    identifierRegex = [NSRegularExpression regularExpressionWithPattern:@"([A-F0-9]{40})"
                                                                 options:0
                                                                   error:NULL];
     NSMutableArray<CodesignIdentity *> *identities = [@[] mutableCopy];

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -27,7 +27,7 @@ const double EPSILON = 0.001;
 }
 
 + (BOOL)isDeviceID:(NSString *)did {
-    return did.length == 40 && [did isBase64];
+    return (did.length == 40 && [did isBase64]) || did.length == 25;
 }
 
 + (FBDevice *)findDeviceByName:(NSString *)name {


### PR DESCRIPTION
**Problem:** Device manager does not support new device id format:
```
Akvelon 8 (12.1) [c25eb5ffd7f1468b1adbafb684b34339ac67c950] - old device id format
Akvelon XS Max (12.0.1) [00008020-00196D9E3650003A] - new device id format
Apple TV (12.1) [DF19D6B2-C13A-4194-BF5E-0DBEA88A53DB] (Simulator) - simulator id format
```

**Changes:**
- Fixed regexes for new devices
- Changed isDeviceID verification
- Added test with new device id
- Changed commands info

---
Verified locally with iPhone XS and iPhone 8 devices.