### PR TITLE
Add signing step

### DIFF
--- a/bin/make/frameworks.sh
+++ b/bin/make/frameworks.sh
@@ -39,3 +39,9 @@ xcrun ditto Vendor/CocoaLumberjack.framework \
   "${OUTPUT_DIR}/CocoaLumberjack.framework" ;
 )
 
+xcrun codesign \
+--force \
+--deep \
+--sign "Mac Developer: Karl Krukow (YTTN6Y2QS9)" \
+--keychain "${HOME}/.calabash/Calabash.keychain" \
+"Frameworks/CocoaLumberjack.framework"

--- a/iOSDeviceManager/main.m
+++ b/iOSDeviceManager/main.m
@@ -5,6 +5,6 @@
 int main(int argc, const char * argv[]) {
     @autoreleasepool {
         [iOSDeviceManagerLogging startLumberjackLogging];
-        return [CLI process:[NSProcessInfo processInfo].arguments];
+        return (int)[CLI process:[NSProcessInfo processInfo].arguments];
     }
 }


### PR DESCRIPTION
In this PR we have added signing step in `bin/make/frameworks.sh` script to avoid `CocoaLumberjack.framework must be signed` error.
Also we have added type conversion to returning value in `iOSDeviceManager/main.m` avoid build errors.