### PR TITLE
Add support for Xcode 10.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "run_loop", github: "calabash/run_loop", branch: "v-malob/xcode-10-3"
+gem "run_loop", github: "calabash/run_loop", branch: "develop"
 gem "rspec", "~> 3.0"
 gem "rspec_junit_formatter", "~> 0.2"
 gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "run_loop", github: "calabash/run_loop", branch: "develop"
+gem "run_loop", github: "calabash/run_loop", branch: "v-malob/xcode-10-3"
 gem "rspec", "~> 3.0"
 gem "rspec_junit_formatter", "~> 0.2"
 gem "pry"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,9 @@ jobs:
 
   strategy:
     matrix:
-      Mojave-Xcode-10.2.1:
+      Mojave-Xcode-10.3:
         IMAGE_POOL: 'macOS-10.14'
-        XCODE_VERSION: '10.2.1'
+        XCODE_VERSION: '10.3'
       Mojave-Xcode-11.0:
         IMAGE_POOL: 'macOS-10.14'
         XCODE_VERSION: '11'

--- a/iOSDeviceManager/Utilities/DeviceUtils.m
+++ b/iOSDeviceManager/Utilities/DeviceUtils.m
@@ -140,6 +140,10 @@ const double EPSILON = 0.001;
     NSUInteger major = XcodeUtils.versionMajor + 2;
     NSUInteger minor = XcodeUtils.versionMinor;
 
+    if(XcodeUtils.versionMajor == 10 && XcodeUtils.versionMinor == 3){
+        minor = 4;
+    }
+    
     NSString *deviceVersion;
 
     if (XcodeUtils.versionMajor == 11) {


### PR DESCRIPTION
- Update utilities method to support Xcode 10.3 (changing minor version for simulator)
- Include configuration Mojave + Xcode 10.3 to the yml file

**Note:** 
pull request contains links to run_loop branch v-malob/xcode-10-3 these changes will be reverted  when run_loop request is merged.