### PR TITLE
Add 'Apple Development' string to isIOSDeveloperIdentity()

### DIFF
--- a/Tests/Unit/Utilities/CodesignIdentityTest.m
+++ b/Tests/Unit/Utilities/CodesignIdentityTest.m
@@ -110,6 +110,15 @@ context(@"#isIOSDeveloperIdentity", ^{
 
         expect([identity isIOSDeveloperIdentity]).to.equal(YES);
     });
+        
+    it(@"returns true if the name contains Apple Development", ^{
+        NSString *shasum, *name;
+        shasum = @"921D006C34510B86D66912F2C58344AC37A6B88E";
+        name = @"Apple Development: Joshua Moody";
+        identity = [[CodesignIdentity alloc] initWithShasum:shasum name:name];
+
+        expect([identity isIOSDeveloperIdentity]).to.equal(YES);
+    });
 
     it(@"returns false if the name does not contain iPhone Developer", ^{
         NSString *shasum, *name;

--- a/iOSDeviceManager/Resigning/CodesignIdentity.m
+++ b/iOSDeviceManager/Resigning/CodesignIdentity.m
@@ -237,7 +237,7 @@
 }
 
 - (BOOL)isIOSDeveloperIdentity {
-    return [self.name containsString:@"iPhone Developer"];
+    return [self.name containsString:@"iPhone Developer"] || [self.name containsString:@"Apple Development"];
 }
 
 - (id)copyWithZone:(NSZone *)zone {


### PR DESCRIPTION
Allows iOSDeviceManager to use certificates with 'Apple Development' text