### PR TITLE
Xcode: use an Apple Distribution profile

### DIFF
--- a/iOSDeviceManager.xcodeproj/project.pbxproj
+++ b/iOSDeviceManager.xcodeproj/project.pbxproj
@@ -1324,7 +1324,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Karl Krukow (YTTN6Y2QS9)";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Karl Krukow (FYD86LA7RE)";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
### Motivation

We had an issue in November where our developer cert was revoked because a credit card expired.  This caused users to see the scary dialog in #269.   If we use a distribution certificate, then we would not have had this problem because the distribution certificates in the developer account were _not_ revoked.

